### PR TITLE
Various SEP fixes

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -101,7 +101,9 @@ interface UIResource {
    * Includes Content Security Policy configuration, dedicated domain settings,
    * and visual preferences.
    */
-  _meta?: UIResourceMeta
+  _meta?: {
+    ui?: UIResourceMeta;
+  }
 }
 
 interface UIResourceMeta {


### PR DESCRIPTION
In the interest of time, this PR bundles together several fixes:

---

**Standardize notification naming and fix formatting in MCP Apps spec**

Updates the MCP Apps specification to consistently use the `ui/notifications/` prefix for all notification methods (e.g., `ui/notifications/sandbox-ready`, `ui/notifications/tool-result`). Also removes trailing whitespace, fixes tab/space inconsistencies, improves code formatting with proper backticks, and clarifies terminology throughout the document.

---

**Fix resource list change notification name format**

Corrected `resources/notifications/list_changed` to `notifications/resources/list_changed` on line 208 to follow standard MCP notification naming pattern (`notifications/{category}/{event}`).

---

**Convert notification examples from JSON to TypeScript format**

Changes code blocks for notification examples to use `typescript` fence instead of `json`. This properly represents TypeScript types (like Record<string, unknown>, CallToolResult, Partial<HostContext>) without quotes, matching the format used elsewhere in the specification.

---

**Remove unnecessary quotes from TypeScript property names**

Unquote ui, csp, domain, and prefersBorder properties in the resources/read response TypeScript example to follow standard TypeScript syntax conventions.

---

**Fix typo in mermaid diagram comment**

Changed "notifation" to "notification" in the interactive phase sequencediagram.

---

**Fix indentation in Mermaid sequence diagram**

Corrects the indentation of nested block structures (alt, opt, par, loop) in all four Mermaid sequence diagrams. Content inside nested blocks is now properly indented relative to the block keywords, making the hierarchical structure clearer and more readable.

---

**Complete JSON-RPC message examples in Data Passing section**

The tool input and tool result examples now show fully formed JSON-RPC messages with all required fields (jsonrpc, id/method, result/params) to better demonstrate the protocol format. Also fixes MDX parsing error in Client\<>Server heading by escaping angle brackets.

---

**Improve CSP example formatting and clarity in apps specification**

Change CSP code block from yaml to typescript fence, add context showing where csp variable originates (resource.\_meta?.ui?.csp), rename cspHeader to cspValue for accuracy, and remove Content-Security-Policy: prefix since the variable holds just the policy value, not a complete HTTP header.

---

**Convert UiResourceMeta documentation to TypeDoc comments**

Move metadata field documentation from separate prose section into TypeDoc comments on the UiResourceMeta interface properties. This consolidates the documentation and eliminates duplication while making it more maintainable and IDE-friendly.

---

**Convert UIResource documentation to TypeDoc comments**

Replace inline comments with comprehensive TypeDoc comments that explain the purpose and usage of each property. Add examples and clarify constraints (MUST/SHOULD) for better developer understanding.

---

**Fix indentation of domain and prefersBorder in UiResourceMeta example**

The domain and prefersBorder properties are now properly indented to be at the same hierarchical level as csp within the ui object.

---

**Fix UIResource \_meta type to match actual usage pattern**

The UIResource interface incorrectly specified `_meta?: UIResourceMeta` when it should be `_meta?: { ui?: UIResourceMeta }` to match the resources/read response format and all usage examples throughout the document.