### PR TITLE
fix: Correct broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo provides:
 - [types.ts](./src/types.ts): Types of JSON-RPC messages used to communicate between Apps & their host
   - Note that MCP Apps also use some standard MCP messages (e.g. `tools/call` for the App to trigger actions on its originating Server - these calls are proxied through the Host), but these types are the additional messages defined by the extension
   
-- [examples/simple-example](./examples/simple-example): Example Server + Apps
+- [examples/simple-server](./examples/simple-server): Example Server + Apps
   - [server.ts](./examples/simple-server/server.ts): MCP server with two tools that declare UI resources of Apps to be show in the chat when called
   - [ui-react.tsx](./examples/simple-server/src/ui-react.tsx): React App returned by the `create-ui-react` tool shows how to use the `useApp` hook to register MCP callbacks
   - [ui-vanilla.tsx](./examples/simple-server/src/ui-vanilla.ts): vanilla App returned by the `create-ui-vanilla`


### PR DESCRIPTION

## Motivation and Context
The directory name was changed from examples/simple-example to examples/simple-server, but the link in the README file was not updated. This PR corrects the link so that users can correctly navigate the repository structure.

examples/simple-example -> examples/simple-server

## How Has This Been Tested?
I have verified that the updated link in the local README.md correctly points to the new examples/simple-server directory.

## Breaking Changes
This is a non-breaking documentation fix.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
N/A