### PR TITLE
sdk: add notification handlers (App.ontoolinput, .ontoolresult, AppBridge.onsizechange...)

### DIFF
--- a/examples/simple-server/src/ui-raw.ts
+++ b/examples/simple-server/src/ui-raw.ts
@@ -8,7 +8,7 @@
  * <code>
  * npx esbuild src/ui-raw.ts --bundle --outfile=dist/ui-raw.js --minify --sourcemap --platform=browser
  * </code>
- * 
+ *
  * We implement a barebones JSON-RPC message sender/receiver (see `app` object below),
  * but without timeouts or runtime type validation of any kind
  * (for that, use the Apps SDK / see ui-vanilla.ts or ui-react.ts).

--- a/examples/simple-server/src/ui-react.tsx
+++ b/examples/simple-server/src/ui-react.tsx
@@ -26,19 +26,9 @@ export function McpClientApp() {
     appInfo: APP_INFO,
     capabilities: {},
     onAppCreated: (app) => {
-      app.setNotificationHandler(
-        McpUiToolResultNotificationSchema,
-        async (notification) => {
-          setToolResults((prev) => [...prev, notification.params]);
-        },
-      );
-      app.setNotificationHandler(
-        McpUiSizeChangeNotificationSchema,
-        async (notification) => {
-          document.body.style.width = `${notification.params.width}px`;
-          document.body.style.height = `${notification.params.height}px`;
-        },
-      );
+      app.ontoolresult = async (params) => {
+        setToolResults((prev) => [...prev, params]);
+      };
     },
   });
 

--- a/examples/simple-server/src/ui-vanilla.ts
+++ b/examples/simple-server/src/ui-vanilla.ts
@@ -36,28 +36,17 @@ window.addEventListener("load", async () => {
     version: "1.0.0",
   });
 
-  app.setNotificationHandler(
-    McpUiToolInputNotificationSchema,
-    async ({ params }) => {
-      appendText(
-        `Tool call input received: ${JSON.stringify(params.arguments)}`,
-      );
-    },
-  );
-  app.setNotificationHandler(
-    McpUiToolResultNotificationSchema,
-    async ({ params: { content, structuredContent, isError } }) => {
-      appendText(
-        `Tool call result received: isError=${isError}, content=${content}, structuredContent=${JSON.stringify(structuredContent)}`,
-      );
-    },
-  );
-  app.setNotificationHandler(
-    McpUiHostContextChangedNotificationSchema,
-    async (params) => {
-      appendText(`Host context changed: ${JSON.stringify(params)}`);
-    },
-  );
+  app.ontoolinput = (params) => {
+    appendText(`Tool call input received: ${JSON.stringify(params.arguments)}`);
+  };
+  app.ontoolresult = ({ content, structuredContent, isError }) => {
+    appendText(
+      `Tool call result received: isError=${isError}, content=${content}, structuredContent=${JSON.stringify(structuredContent)}`,
+    );
+  };
+  app.onhostcontextchanged = (params) => {
+    appendText(`Host context changed: ${JSON.stringify(params)}`);
+  };
 
   document.body.addEventListener("resize", () => {
     app.sendSizeChange({

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,8 @@ import {
   LATEST_PROTOCOL_VERSION,
   McpUiAppCapabilities,
   McpUiHostCapabilities,
+  McpUiHostContextChangedNotification,
+  McpUiHostContextChangedNotificationSchema,
   McpUiInitializedNotification,
   McpUiInitializeRequest,
   McpUiInitializeResultSchema,
@@ -27,6 +29,12 @@ import {
   McpUiOpenLinkRequest,
   McpUiOpenLinkResultSchema,
   McpUiSizeChangeNotification,
+  McpUiToolInputNotification,
+  McpUiToolInputNotificationSchema,
+  McpUiToolInputPartialNotification,
+  McpUiToolInputPartialNotificationSchema,
+  McpUiToolResultNotification,
+  McpUiToolResultNotificationSchema,
 } from "./types";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
@@ -52,6 +60,36 @@ export class App extends Protocol<Request, Notification, Result> {
       console.log("Received ping:", request.params);
       return {};
     });
+  }
+
+  set ontoolinput(
+    callback: (params: McpUiToolInputNotification["params"]) => void,
+  ) {
+    this.setNotificationHandler(McpUiToolInputNotificationSchema, (n) =>
+      callback(n.params),
+    );
+  }
+  set ontoolinputpartial(
+    callback: (params: McpUiToolInputPartialNotification["params"]) => void,
+  ) {
+    this.setNotificationHandler(McpUiToolInputPartialNotificationSchema, (n) =>
+      callback(n.params),
+    );
+  }
+  set ontoolresult(
+    callback: (params: McpUiToolResultNotification["params"]) => void,
+  ) {
+    this.setNotificationHandler(McpUiToolResultNotificationSchema, (n) =>
+      callback(n.params),
+    );
+  }
+  set onhostcontextchanged(
+    callback: (params: McpUiHostContextChangedNotification["params"]) => void,
+  ) {
+    this.setNotificationHandler(
+      McpUiHostContextChangedNotificationSchema,
+      (n) => callback(n.params),
+    );
   }
 
   assertCapabilityForMethod(method: Request["method"]): void {

--- a/src/react/useApp.tsx
+++ b/src/react/useApp.tsx
@@ -9,8 +9,7 @@ export interface UseAppOptions {
   capabilities: McpUiAppCapabilities;
   /**
    * Called after client is created but before connection.
-   * Use this to register request/notification handlers via
-   * client.setRequestHandler() and client.setNotificationHandler().
+   * Use this to register handlers via app.ontoolinput, app.toolresult, etc.
    */
   onAppCreated?: (app: App) => void;
 }


### PR DESCRIPTION
This simplifies the syntax quite a bit for users of either class