### PR TITLE
Make params optional in McpUiInitializedNotificationSchema

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -221,7 +221,7 @@ export type McpUiInitializeResult = z.infer<typeof McpUiInitializeResultSchema>;
 
 export const McpUiInitializedNotificationSchema = z.object({
   method: z.literal("ui/notifications/initialized"),
-  params: z.object({}),
+  params: z.object({}).optional(),
 });
 export type McpUiInitializedNotification = z.infer<
   typeof McpUiInitializedNotificationSchema


### PR DESCRIPTION
## Summary
- Makes `params` optional in `McpUiInitializedNotificationSchema` to accept notifications sent without explicit params

## Problem
Notifications like this were being rejected by schema validation:
```typescript
await this.notification(<McpUiInitializedNotification>{
  method: "ui/notifications/initialized",
});
```

The schema required `params` to be present, even though an empty object `{}` has no required fields.

## Test plan
- [x] Verify notifications without `params` are now accepted by the schema
- [ ] Existing code that passes `params: {}` continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)