### PR TITLE
Add ReadResourceRequestSchema forwarding for resources capability

### DIFF
--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -12,6 +12,8 @@ import {
   ListResourcesResultSchema,
   ListResourceTemplatesRequestSchema,
   ListResourceTemplatesResultSchema,
+  ReadResourceRequestSchema,
+  ReadResourceResultSchema,
   LoggingMessageNotification,
   LoggingMessageNotificationSchema,
   Notification,
@@ -270,6 +272,10 @@ export class AppBridge extends Protocol<Request, Notification, Result> {
       this.forwardRequest(
         ListResourceTemplatesRequestSchema,
         ListResourceTemplatesResultSchema,
+      );
+      this.forwardRequest(
+        ReadResourceRequestSchema,
+        ReadResourceResultSchema,
       );
       if (serverCapabilities.resources.listChanged) {
         this.forwardNotification(ResourceListChangedNotificationSchema);


### PR DESCRIPTION
## Summary
- Adds missing `ReadResourceRequestSchema` forwarding when resources capability is enabled

## Problem
The resources capability was forwarding:
- ✅ `ListResourcesRequestSchema` 
- ✅ `ListResourceTemplatesRequestSchema`
- ❌ `ReadResourceRequestSchema` (missing)

This meant clients could list resources but not actually read them.

## Test plan
- [ ] Verify resource reading works through the app bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)