### PR TITLE
Fix `zod` mismatch issue. Fixes `npm i` 

### DIFF
--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -1,5 +1,5 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { ZodLiteral, ZodObject } from "zod";
+import { ZodLiteral, ZodObject } from "zod/v4";
 
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import {
   RequestSchema,
   ToolSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 export const LATEST_PROTOCOL_VERSION = "2025-11-21";
 
@@ -77,7 +77,7 @@ export type McpUiSizeChangeNotification = z.infer<
 export const McpUiToolInputNotificationSchema = z.object({
   method: z.literal("ui/notifications/tool-input"),
   params: z.object({
-    arguments: z.record(z.unknown()).optional(),
+    arguments: z.record(z.string(), z.unknown()).optional(),
   }),
 });
 export type McpUiToolInputNotification = z.infer<
@@ -87,7 +87,7 @@ export type McpUiToolInputNotification = z.infer<
 export const McpUiToolInputPartialNotificationSchema = z.object({
   method: z.literal("ui/notifications/tool-input-partial"),
   params: z.object({
-    arguments: z.record(z.unknown()).optional(),
+    arguments: z.record(z.string(), z.unknown()).optional(),
   }),
 });
 export type McpUiToolInputPartialNotification = z.infer<


### PR DESCRIPTION
Currently, when you run `npm i`, it triggers a build script that breaks. See this issue. 
https://github.com/modelcontextprotocol/ext-apps/issues/32

There was a mismatch in zod versions being used. The SDK requires zod v4 but the project impored zod v3. We update the imports in `app-bridge.ts` and `types.ts` to use zod v4. 

After: 
<img width="1260" height="646" alt="Screenshot 2025-11-27 at 1 43 41 PM" src="https://github.com/user-attachments/assets/b34eabe8-00a1-4d96-bad4-1d3d44d9a5b1" />

## Motivation and Context
Fixes broken `npm i`

## How Has This Been Tested?
I ran `npm i` and confirmed that the build works and dependencies are properly installed. 

## Breaking Changes
NA

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
NA
