### PR TITLE
Fix React UI tool call example

### DIFF
--- a/examples/simple-server/src/ui-react.tsx
+++ b/examples/simple-server/src/ui-react.tsx
@@ -37,7 +37,7 @@ export function McpClientApp() {
     try {
       const result = await app.callServerTool({
         name: "get-weather",
-        arguments: { city: "Tokyo" },
+        arguments: { location: "Tokyo" },
       });
       setMessages((prev) => [
         ...prev,


### PR DESCRIPTION
In the `callServerTool` of the React widget example, we pass in the parameter `city`. However, the parameter is supposed to be `location`. See this line in `server.ts`: 

https://github.com/modelcontextprotocol/ext-apps/blob/main/examples/simple-server/server.ts#L164

See tool call action working; 
https://github.com/user-attachments/assets/1f060616-bd37-4f74-bc77-3fe25af3e64a

## Motivation and Context
Fixes the tool call action 

## How Has This Been Tested?
Tested in MCPJam. Confirmed that the tool call action is working as expected 

## Breaking Changes
NA

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
