### PR TITLE
fix: remove carousel display mode

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -401,7 +401,7 @@ interface HostContext {
   /** Current color theme preference */
   theme?: "light" | "dark" | "system";
   /** How the UI is currently displayed */
-  displayMode?: "inline" | "fullscreen" | "pip" | "carousel";
+  displayMode?: "inline" | "fullscreen" | "pip";
   /** Display modes the host supports */
   availableDisplayModes?: string[];
   /** Current and maximum dimensions available to the UI */

--- a/src/types.ts
+++ b/src/types.ts
@@ -430,7 +430,7 @@ export interface McpUiHostContext {
    * How the UI is currently displayed.
    * @example "inline"
    */
-  displayMode?: "inline" | "fullscreen" | "pip" | "carousel";
+  displayMode?: "inline" | "fullscreen" | "pip";
   /**
    * Display modes the host supports.
    * Apps can use this to offer mode-switching UI if applicable.
@@ -502,7 +502,7 @@ export const McpUiHostContextSchema: z.ZodType<McpUiHostContext> = z.object({
     })
     .optional(),
   theme: z.enum(["light", "dark", "system"]).optional(),
-  displayMode: z.enum(["inline", "fullscreen", "pip", "carousel"]).optional(),
+  displayMode: z.enum(["inline", "fullscreen", "pip"]).optional(),
   availableDisplayModes: z.array(z.string()).optional(),
   viewport: z
     .object({


### PR DESCRIPTION
Carousel display mode was added as a placeholder, removed, and somehow ended back in.

## Motivation and Context
Carousel isn't required at this point. We've received feedback that its purpose is unclear.
I think we should address additional display modes as the need arises.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
