### PR TITLE
docs: remove "Mobile" from safeAreaInsets comment

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -424,7 +424,7 @@ interface HostContext {
     touch?: boolean;
     hover?: boolean;
   }
-  /** Mobile safe area boundaries in pixels */
+  /** Safe area boundaries in pixels */
   safeAreaInsets?: {
     top: number;
     right: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -475,8 +475,8 @@ export interface McpUiHostContext {
     hover?: boolean;
   };
   /**
-   * Mobile safe area boundaries in pixels.
-   * Used to avoid notches, rounded corners, and system UI on mobile devices.
+   * Safe area boundaries in pixels.
+   * Used to avoid notches, rounded corners, and system UI.
    */
   safeAreaInsets?: {
     /** Top safe area inset in pixels */


### PR DESCRIPTION
## Summary
- Removed "Mobile" from `safeAreaInsets` comment since safe area insets apply on web as well, not just mobile devices

## Changes
- `specification/draft/apps.mdx`: Updated comment from "Mobile safe area boundaries" to "Safe area boundaries"
- `src/types.ts`: Same update, plus removed "on mobile devices" from the description

🤖 Generated with [Claude Code](https://claude.com/claude-code)