### PR TITLE
fix: correct host-context-changed notification name in spec

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -647,12 +647,12 @@ Host SHOULD wait for a response before tearing down the resource (to prevent dat
 
 Guest UI SHOULD send this notification when rendered content body size changes (e.g. using ResizeObserver API to report up to date size).
 
-`ui/host-context-change` - Host context has changed
+`ui/notifications/host-context-changed` - Host context has changed
 
 ```typescript
 {
   jsonrpc: "2.0",
-  method: "ui/host-context-change",
+  method: "ui/notifications/host-context-changed",
   params: Partial<HostContext>  // See HostContext type above
 }
 ```
@@ -777,7 +777,7 @@ sequenceDiagram
       UI ->> H: notifications (e.g., ui/notifications/size-change)
     end
     opt Host notifications
-      H ->> UI: notifications (e.g., ui/notifications/host-context-change)
+      H ->> UI: notifications (e.g., ui/notifications/host-context-changed)
     end
   end
 ```


### PR DESCRIPTION
## Summary

- Updates `ui/host-context-change` to `ui/notifications/host-context-changed` in the spec
- Aligns with the SDK implementation (`src/types.ts`, `src/app-bridge.ts`)
- Follows the `ui/notifications/*` naming convention for notifications

## Test plan

- [x] Verified SDK already uses `ui/notifications/host-context-changed`
- [x] All 3 occurrences in spec updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)