### PR TITLE
fix: remove 'system' from theme type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -425,7 +425,7 @@ export interface McpUiHostContext {
    * Current color theme preference.
    * @example "dark"
    */
-  theme?: "light" | "dark" | "system";
+  theme?: "light" | "dark";
   /**
    * How the UI is currently displayed.
    * @example "inline"


### PR DESCRIPTION
## Summary

Remove `'system'` from the theme type, leaving only `'light' | 'dark'`.

## Rationale

1. **Spec alignment**: The spec already only defines `"light" | "dark"` (line 402 in apps.mdx)
2. **OpenAI Apps SDK compatibility**: Their [theme API](https://developers.openai.com/apps-sdk/build/chatgpt-ui) only supports `'light' | 'dark'`
3. **Host responsibility**: The host should resolve system preference to an actual theme value before sending to the app

## Changes

- `src/types.ts`: `theme?: "light" | "dark" | "system"` → `theme?: "light" | "dark"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)