### PR TITLE
Temporal fix: Handle wrapped JSON-RPC responses in callServerTool

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -581,11 +581,17 @@ export class App extends Protocol<Request, Notification, Result> {
     params: CallToolRequest["params"],
     options?: RequestOptions,
   ): Promise<CallToolResult> {
-    return await this.request(
+    const response = await this.request(
       { method: "tools/call", params },
       CallToolResultSchema,
       options,
     );
+    // TEMPORAL HACK: Some host implementations incorrectly return the full
+    // JSON-RPC envelope instead of just the result. Unwrap if needed.
+    if (response && "result" in response && "jsonrpc" in response) {
+      return (response as unknown as { result: CallToolResult }).result;
+    }
+    return response;
   }
 
   /**


### PR DESCRIPTION
## Summary

**This is a temporal workaround** until host implementations properly unwrap JSON-RPC responses.

Some host implementations incorrectly return the full JSON-RPC envelope instead of just the unwrapped result from `callServerTool()`. This causes apps to fail when accessing `result.content`.

## Problem

Apps using `callServerTool()` receive:
```json
{
  "result": { "content": [...] },
  "jsonrpc": "2.0",
  "id": 1
}
```

But expect:
```json
{ "content": [...] }
```

## Solution

Add a temporal hack in `callServerTool()` to detect and unwrap the JSON-RPC envelope when present. This can be removed once host implementations are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)