### PR TITLE
Fix widget layout to use full available width

### DIFF
--- a/examples/basic-host/src/index.module.css
+++ b/examples/basic-host/src/index.module.css
@@ -113,9 +113,8 @@
   min-height: 200px;
 
   iframe {
-    flex-shrink: 0;
-    height: 100%;
-    max-width: 100%;
+    flex: 1 0 auto;
+    height: 600px;
     box-sizing: border-box;
     border: 3px dashed #888;
     border-radius: 4px;

--- a/examples/budget-allocator-server/src/mcp-app.css
+++ b/examples/budget-allocator-server/src/mcp-app.css
@@ -40,7 +40,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 600px;
-  width: 600px;
+  width: 100%;
   max-width: 100%;
   max-height: 100%;
   overflow: hidden;

--- a/examples/customer-segmentation-server/src/mcp-app.css
+++ b/examples/customer-segmentation-server/src/mcp-app.css
@@ -37,7 +37,7 @@ html, body {
 }
 
 .main {
-  width: 600px;
+  width: 100%;
   height: 600px;
   margin: 0 auto;
   padding: 12px;

--- a/examples/scenario-modeler-server/src/mcp-app.css
+++ b/examples/scenario-modeler-server/src/mcp-app.css
@@ -37,7 +37,7 @@
    ============================================================================ */
 
 .main {
-  width: 600px;
+  width: 100%;
   height: 600px;
   overflow: hidden;
   background: var(--bg-primary);

--- a/examples/system-monitor-server/src/mcp-app.css
+++ b/examples/system-monitor-server/src/mcp-app.css
@@ -36,7 +36,7 @@ html, body {
 }
 
 .main {
-  width: 600px;
+  width: 100%;
   margin: 0 auto;
   padding: 16px;
   display: flex;


### PR DESCRIPTION
## Summary
- Change marketing widget containers from fixed 600px to `width: 100%`
- Update basic-host iframe to use `flex: 1` for proper expansion
- Widgets now fill their parent container instead of fixed size

## Changes
- `examples/budget-allocator-server/src/mcp-app.css`
- `examples/customer-segmentation-server/src/mcp-app.css`
- `examples/scenario-modeler-server/src/mcp-app.css`
- `examples/system-monitor-server/src/mcp-app.css`
- `examples/basic-host/src/index.module.css`

## Test plan
- [x] Widgets expand to fill available width in basic-host
- [x] Height remains at 600px
- [x] All 5 marketing examples work correctly

<img width="981" height="884" alt="Screenshot 2025-12-08 at 13 51 11" src="https://github.com/user-attachments/assets/f816ed75-dc21-45c3-b316-8c576e6a8e3f" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)