### PR TITLE
Remove temporary JSON-RPC envelope unwrapping hack

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -597,17 +597,11 @@ export class App extends Protocol<Request, Notification, Result> {
     params: CallToolRequest["params"],
     options?: RequestOptions,
   ): Promise<CallToolResult> {
-    const response = await this.request(
+    return await this.request(
       { method: "tools/call", params },
       CallToolResultSchema,
       options,
     );
-    // TEMPORAL HACK: Some host implementations incorrectly return the full
-    // JSON-RPC envelope instead of just the result. Unwrap if needed.
-    if (response && "result" in response && "jsonrpc" in response) {
-      return (response as unknown as { result: CallToolResult }).result;
-    }
-    return response;
   }
 
   /**


### PR DESCRIPTION
## Summary
Remove the temporary workaround added in #82 that unwrapped incorrectly-formatted JSON-RPC responses.

The host implementation has been fixed to return the correct result format, so this hack is no longer needed.

## Changes
- `src/app.ts`: Remove the `TEMPORAL HACK` code block in `callServerTool()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)