### PR TITLE
examples: handle server errors

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -153,7 +153,11 @@ app.post("/mcp", async (req, res) => {
   await transport.handleRequest(req, res, req.body);
 });
 
-app.listen(3001, () => {
+app.listen(3001, (err) => {
+  if (err) {
+    console.error("Error starting server:", err);
+    process.exit(1);
+  }
   console.log("Server listening on http://localhost:3001/mcp");
 });
 ```

--- a/examples/basic-host/serve.ts
+++ b/examples/basic-host/serve.ts
@@ -70,11 +70,19 @@ sandboxApp.use((_req, res) => {
 });
 
 // ============ Start both servers ============
-hostApp.listen(HOST_PORT, () => {
+hostApp.listen(HOST_PORT, err => {
+  if (err) {
+    console.error("Error starting server:", err);
+    process.exit(1);
+  }
   console.log(`Host server:    http://localhost:${HOST_PORT}`);
 });
 
-sandboxApp.listen(SANDBOX_PORT, () => {
+sandboxApp.listen(SANDBOX_PORT, err => {
+  if (err) {
+    console.error("Error starting server:", err);
+    process.exit(1);
+  }
   console.log(`Sandbox server: http://localhost:${SANDBOX_PORT}`);
   console.log("\nPress Ctrl+C to stop\n");
 });

--- a/examples/basic-server-react/server.ts
+++ b/examples/basic-server-react/server.ts
@@ -85,7 +85,11 @@ app.post("/mcp", async (req: Request, res: Response) => {
   }
 });
 
-const httpServer = app.listen(PORT, () => {
+const httpServer = app.listen(PORT, err => {
+  if (err) {
+    console.error("Error starting server:", err);
+    process.exit(1);
+  }
   console.log(`Server listening on http://localhost:${PORT}/mcp`);
 });
 

--- a/examples/basic-server-vanillajs/server.ts
+++ b/examples/basic-server-vanillajs/server.ts
@@ -85,7 +85,11 @@ app.post("/mcp", async (req: Request, res: Response) => {
   }
 });
 
-const httpServer = app.listen(PORT, () => {
+const httpServer = app.listen(PORT, err => {
+  if (err) {
+    console.error("Error starting server:", err);
+    process.exit(1);
+  }
   console.log(`Server listening on http://localhost:${PORT}/mcp`);
 });
 

--- a/examples/budget-allocator-server/server.ts
+++ b/examples/budget-allocator-server/server.ts
@@ -330,7 +330,11 @@ async function main() {
       }
     });
 
-    const httpServer = app.listen(PORT, () => {
+    const httpServer = app.listen(PORT, (err) => {
+      if (err) {
+        console.error("Error starting server:", err);
+        process.exit(1);
+      }
       console.log(
         `Budget Allocator Server listening on http://localhost:${PORT}/mcp`,
       );

--- a/examples/cohort-heatmap-server/server.ts
+++ b/examples/cohort-heatmap-server/server.ts
@@ -240,7 +240,11 @@ async function main() {
       }
     });
 
-    const httpServer = app.listen(PORT, () => {
+    const httpServer = app.listen(PORT, (err) => {
+      if (err) {
+        console.error("Error starting server:", err);
+        process.exit(1);
+      }
       console.log(
         `Cohort Heatmap Server listening on http://localhost:${PORT}/mcp`,
       );

--- a/examples/customer-segmentation-server/server.ts
+++ b/examples/customer-segmentation-server/server.ts
@@ -139,7 +139,11 @@ async function main() {
       }
     });
 
-    const httpServer = app.listen(PORT, () => {
+    const httpServer = app.listen(PORT, (err) => {
+      if (err) {
+        console.error("Error starting server:", err);
+        process.exit(1);
+      }
       console.log(
         `Customer Segmentation Server listening on http://localhost:${PORT}/mcp`,
       );

--- a/examples/scenario-modeler-server/server.ts
+++ b/examples/scenario-modeler-server/server.ts
@@ -346,7 +346,11 @@ async function main() {
       }
     });
 
-    const httpServer = app.listen(PORT, () => {
+    const httpServer = app.listen(PORT, (err) => {
+      if (err) {
+        console.error("Error starting server:", err);
+        process.exit(1);
+      }
       console.log(
         `SaaS Scenario Modeler Server listening on http://localhost:${PORT}/mcp`,
       );

--- a/examples/system-monitor-server/server.ts
+++ b/examples/system-monitor-server/server.ts
@@ -211,7 +211,11 @@ async function main() {
       }
     });
 
-    const httpServer = app.listen(PORT, () => {
+    const httpServer = app.listen(PORT, (err) => {
+      if (err) {
+        console.error("Error starting server:", err);
+        process.exit(1);
+      }
       console.log(
         `System Monitor Server listening on http://localhost:${PORT}/mcp`,
       );


### PR DESCRIPTION
Useful to avoid mysterious failures when port already in use