### PR TITLE
docs: add Bun installation step to customer-segmentation-server README

### DIFF
--- a/examples/customer-segmentation-server/README.md
+++ b/examples/customer-segmentation-server/README.md
@@ -22,13 +22,19 @@ A demo MCP App that displays customer data as an interactive scatter/bubble char
 
 ## Running
 
-1. Install dependencies:
+1. Install [Bun](https://github.com/oven-sh/bun) (if not already installed):
+
+   ```bash
+   curl -fsSL https://bun.com/install | bash
+   ```
+
+2. Install dependencies:
 
    ```bash
    npm install
    ```
 
-2. Build and start the server:
+3. Build and start the server:
 
    ```bash
    npm start
@@ -36,7 +42,7 @@ A demo MCP App that displays customer data as an interactive scatter/bubble char
 
    The server will listen on `http://localhost:3001/mcp`.
 
-3. View using the [`basic-host`](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/basic-host) example or another MCP Apps-compatible host.
+4. View using the [`basic-host`](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/basic-host) example or another MCP Apps-compatible host.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Adds Bun installation instructions as step 1 in the Running section
- Links to the official Bun repository
- Renumbers existing steps accordingly

## Test plan
- [x] README renders correctly with the new step

🤖 Generated with [Claude Code](https://claude.com/claude-code)