### PR TITLE
Deploy docs to GitHub Pages on release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,8 @@ name: Deploy Documentation
 
 on:
   workflow_dispatch:
-  # Future: Uncomment to auto-deploy on release
-  # release:
-  #   types: [published]
+  release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
Automatically publish documentation when a new release is created, ensuring docs stay in sync with published package versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
