### PR TITLE
Add `media-src` to CSP for video and audio support

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -125,11 +125,11 @@ interface UIResourceMeta {
      */
     connectDomains?: string[],
     /**
-     * Origins for static resources (images, scripts, stylesheets, fonts)
+     * Origins for static resources (images, scripts, stylesheets, fonts, media)
      *
      * - Empty or omitted = no external resources (secure default)
      * - Wildcard subdomains supported: `https://*.example.com`
-     * - Maps to CSP `img-src`, `script-src`, `style-src`, `font-src` directives
+     * - Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives
      *
      * @example
      * ["https://cdn.jsdelivr.net", "https://*.cloudflare.com"]
@@ -202,6 +202,7 @@ The resource content is returned via `resources/read`:
   script-src 'self' 'unsafe-inline';
   style-src 'self' 'unsafe-inline';
   img-src 'self' data:;
+  media-src 'self' data:;
   connect-src 'none';
   ```
 
@@ -1114,6 +1115,7 @@ const cspValue = `
   connect-src 'self' ${csp?.connectDomains?.join(' ') || ''};
   img-src 'self' data: ${csp?.resourceDomains?.join(' ') || ''};
   font-src 'self' ${csp?.resourceDomains?.join(' ') || ''};
+  media-src 'self' data: ${csp?.resourceDomains?.join(' ') || ''};
   frame-src 'none';
   object-src 'none';
   base-uri 'self';

--- a/src/types.ts
+++ b/src/types.ts
@@ -837,7 +837,7 @@ type _VerifyInitializedNotification = VerifySchemaMatches<
 export const McpUiResourceCspSchema = z.object({
   /** Origins for network requests (fetch/XHR/WebSocket). Maps to CSP connect-src */
   connectDomains: z.array(z.string()).optional(),
-  /** Origins for static resources (images, scripts, stylesheets, fonts). Maps to CSP img-src, script-src, style-src, font-src */
+  /** Origins for static resources (images, scripts, stylesheets, fonts, media). Maps to CSP img-src, script-src, style-src, font-src, media-src */
   resourceDomains: z.array(z.string()).optional(),
 });
 export type McpUiResourceCsp = z.infer<typeof McpUiResourceCspSchema>;


### PR DESCRIPTION
This adds the `media-src` directive to the Content Security Policy to enable MCP Apps to play video and audio content.

Changes:
- Add `media-src` to the restrictive default CSP in the spec
- Add `media-src` to the CSP construction from metadata in the spec
- Update `resourceDomains` documentation in spec to include media
- Update `resourceDomains` JSDoc in src/types.ts to include `media-src`

Fixes modelcontextprotocol/ext-apps#106

