### PR TITLE
Fix mimeType, CSP settings and QR code example

### DIFF
--- a/examples/basic-host/sandbox.html
+++ b/examples/basic-host/sandbox.html
@@ -2,22 +2,8 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <!-- Permissive CSP so nested content is not constrained by host CSP -->
-    <meta http-equiv="Content-Security-Policy" content="
-      default-src 'self';
-      img-src * data: blob: 'unsafe-inline';
-      media-src * blob: data:;
-      font-src * blob: data:;
-      script-src 'self'
-                 'wasm-unsafe-eval'
-                 'unsafe-inline'
-                 'unsafe-eval'
-                 blob: data: http://localhost:* https://localhost:*;
-      style-src * blob: data: 'unsafe-inline';
-      connect-src *;
-      frame-src * blob: data: http://localhost:* https://localhost:*;
-      base-uri 'self';
-    " />
+    <!-- CSP is set by serve.ts HTTP header - no meta tag needed here
+         The inner iframe's CSP is dynamically injected based on resource metadata -->
     <title>MCP-UI Proxy</title>
     <style>
       html,

--- a/examples/basic-host/src/sandbox.ts
+++ b/examples/basic-host/src/sandbox.ts
@@ -56,17 +56,55 @@ const PROXY_READY_NOTIFICATION: McpUiSandboxProxyReadyNotification["method"] =
 // Special case: The "ui/notifications/sandbox-proxy-ready" message is
 // intercepted here (not relayed) because the Sandbox uses it to configure and
 // load the inner iframe with the Guest UI HTML content.
+// Build CSP meta tag from domains
+function buildCspMetaTag(csp?: { connectDomains?: string[]; resourceDomains?: string[] }): string {
+  const resourceDomains = csp?.resourceDomains?.join(" ") ?? "";
+  const connectDomains = csp?.connectDomains?.join(" ") ?? "";
+
+  // Base CSP directives
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: ${resourceDomains}`.trim(),
+    `style-src 'self' 'unsafe-inline' blob: data: ${resourceDomains}`.trim(),
+    `img-src 'self' data: blob: ${resourceDomains}`.trim(),
+    `font-src 'self' data: blob: ${resourceDomains}`.trim(),
+    `connect-src 'self' ${connectDomains}`.trim(),
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+  ];
+
+  return `<meta http-equiv="Content-Security-Policy" content="${directives.join("; ")}">`;
+}
+
 window.addEventListener("message", async (event) => {
   if (event.source === window.parent) {
     // NOTE: In production you'll also want to validate `event.origin` against
     // your Host domain.
     if (event.data && event.data.method === RESOURCE_READY_NOTIFICATION) {
-      const { html, sandbox } = event.data.params;
+      const { html, sandbox, csp } = event.data.params;
       if (typeof sandbox === "string") {
         inner.setAttribute("sandbox", sandbox);
       }
       if (typeof html === "string") {
-        inner.srcdoc = html;
+        // Inject CSP meta tag at the start of <head> if CSP is provided
+        console.log("[Sandbox] Received CSP:", csp);
+        let modifiedHtml = html;
+        if (csp) {
+          const cspMetaTag = buildCspMetaTag(csp);
+          console.log("[Sandbox] Injecting CSP meta tag:", cspMetaTag);
+          // Insert after <head> tag if present, otherwise prepend
+          if (modifiedHtml.includes("<head>")) {
+            modifiedHtml = modifiedHtml.replace("<head>", `<head>\n${cspMetaTag}`);
+          } else if (modifiedHtml.includes("<head ")) {
+            modifiedHtml = modifiedHtml.replace(/<head[^>]*>/, `$&\n${cspMetaTag}`);
+          } else {
+            modifiedHtml = cspMetaTag + modifiedHtml;
+          }
+        } else {
+          console.log("[Sandbox] No CSP provided, using default");
+        }
+        inner.srcdoc = modifiedHtml;
       }
     } else {
       if (inner && inner.contentWindow) {

--- a/examples/qr-server/requirements.txt
+++ b/examples/qr-server/requirements.txt
@@ -1,2 +1,2 @@
-mcp[cli]>=1.0.0
+mcp[cli]>=1.23.3
 qrcode[pil]>=7.4

--- a/examples/qr-server/widget.html
+++ b/examples/qr-server/widget.html
@@ -26,7 +26,7 @@
 <body>
   <div id="qr"></div>
   <script type="module">
-    import { App, PostMessageTransport } from "https://unpkg.com/@modelcontextprotocol/ext-apps@0.0.4";
+    import { App, PostMessageTransport } from "https://unpkg.com/@modelcontextprotocol/ext-apps@0.0.1";
 
     const app = new App({ name: "QR Widget", version: "1.0.0" });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -79,7 +79,7 @@ export const RESOURCE_URI_META_KEY = "ui/resourceUri";
 /**
  * MIME type for MCP UI resources.
  */
-export const RESOURCE_MIME_TYPE = "text/html;profile=mcp";
+export const RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
 
 /**
  * Options for configuring App behavior.

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,6 +248,13 @@ export interface McpUiSandboxResourceReadyNotification {
     html: string;
     /** Optional override for the inner iframe's sandbox attribute */
     sandbox?: string;
+    /** CSP configuration from resource metadata */
+    csp?: {
+      /** Origins for network requests (fetch/XHR/WebSocket) */
+      connectDomains?: string[];
+      /** Origins for static resources (scripts, images, styles, fonts) */
+      resourceDomains?: string[];
+    };
   };
 }
 
@@ -260,6 +267,12 @@ export const McpUiSandboxResourceReadyNotificationSchema = z.object({
   params: z.object({
     html: z.string(),
     sandbox: z.string().optional(),
+    csp: z
+      .object({
+        connectDomains: z.array(z.string()).optional(),
+        resourceDomains: z.array(z.string()).optional(),
+      })
+      .optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary

- Fix `RESOURCE_MIME_TYPE` constant to match spec: `text/html;profile=mcp-app` (was incorrectly `text/html;profile=mcp`)
- Add CSP field to `McpUiSandboxResourceReadyNotification` type and schema for passing security policy from resources to sandbox
- Update basic-host to extract and pass CSP metadata from resource `_meta.ui.csp`
- Update sandbox.ts to dynamically inject CSP meta tag into inner iframe based on resource metadata
- Remove static CSP from sandbox.html (now dynamic per-resource)
- Update QR server to use custom `read_resource` handler for `_meta` injection (FastMCP workaround)
- Update requirements.txt to require `mcp[cli]>=1.23.3`

## Test plan

- [x] Build project with `npm run build`
- [x] Start QR server: `cd examples/qr-server && python server.py`
- [x] Start basic-host: `cd examples/basic-host && SERVERS='["http://localhost:3108/mcp"]' bun serve.ts`
- [x] Open http://localhost:8080, select QR Server, call `generate_qr` with `{"text": "https://example.com"}`
- [x] Verify QR code renders in widget (SDK loads from unpkg.com via CSP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)