### PR TITLE
fix: ui/tool-cancelled -> ui/notifications/tool-cancelled

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -586,12 +586,12 @@ Guest UI behavior (optional):
 
 Host MUST send this notification when tool execution completes (if UI is displayed during tool execution).
 
-`ui/tool-cancelled` - Tool execution was cancelled
+`ui/notifications/tool-cancelled` - Tool execution was cancelled
 
 ```typescript
 {
   jsonrpc: "2.0",
-  method: "ui/tool-cancelled",
+  method: "ui/notifications/tool-cancelled",
   params: {
     reason: string
   }


### PR DESCRIPTION
Replace instances of `ui/tool-cancelled` with the standard `ui/notifications/tool-cancelled`