### PR TITLE
Preserve existing files on `gh-pages` during docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,4 +25,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
           publish_branch: gh-pages
-          force_orphan: true
+          keep_files: true


### PR DESCRIPTION
Replace `force_orphan` with `keep_files` in `peaceiris/actions-gh-pages` to prevent wiping manually-added files (like screenshots) when deploying generated documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
