### PR TITLE
docs: add styles to MCP Apps specification

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -437,10 +437,6 @@ interface HostContext {
 }
 ```
 
-All fields are optional. Hosts SHOULD provide relevant context. Guest UIs SHOULD handle missing fields gracefully.
-
-For `styles`, apps SHOULD provide CSS fallback values (e.g., `var(--color-text-primary, #171717)`) to handle hosts that don't supply styles.
-
 Example:
 
 ```json
@@ -457,7 +453,8 @@ Example:
       "styles": {
         "--color-background-primary": "light-dark(#ffffff, #171717)",
         "--color-text-primary": "light-dark(#171717, #fafafa)",
-        "--font-family-sans": "system-ui, sans-serif"
+        "--font-family-sans": "system-ui, sans-serif",
+        ...
       },
       "displayMode": "inline",
       "viewport": { "width": 400, "height": 300 }
@@ -468,9 +465,9 @@ Example:
 
 ### Theming
 
-Hosts pass CSS custom properties via `HostContext.styles` for visual cohesion with the host environment.
+Hosts can optionally pass CSS custom properties via `HostContext.styles` for visual cohesion with the host environment.
 
-#### Standardized Variables
+#### Current Standardized Variables
 
 | Category | Variables |
 |----------|-----------|
@@ -489,26 +486,27 @@ Hosts pass CSS custom properties via `HostContext.styles` for visual cohesion wi
 
 #### Host Behavior
 
-- Hosts MAY provide any subset of standardized variables
-- Hosts MAY use CSS `light-dark()` function for theme-aware values
-- `theme` indicates the active mode; `styles` provides the concrete CSS values
+- Hosts can provide any subset of standardized variables, or not pass `styles` at all. However, passing all of the standardized properties is recommended for cohesiveness
+- Hosts can use the CSS `light-dark()` function for theme-aware values
 
 #### App Behavior
 
-- Apps SHOULD use fallback values for CSS variables: `var(--color-text-primary, #171717)`
-- This ensures graceful degradation when hosts omit `styles` or specific variables
-- When the host uses `light-dark()` values, apps MUST set `color-scheme` on their document:
-  ```css
-  :root { color-scheme: light dark; }
-  ```
+- Apps should set default fallback values for CSS variables, to account for hosts who don't pass some or all style variables. This ensures graceful degradation when hosts omit `styles` or specific variables:
+```
+:root {
+  --colorTextPrimary: #171717;
+}
+```
+- Apps can use the `applyHostStyles` utility (or `useHostStyles` if they prefer a React hook) to easily populate the host-provided CSS variables into their style sheet
+- Apps can use the `applyDocumentTheme` utility (or `useDocumentTheme` if they prefer a React hook) to easily respond to Host Context `theme` changes in a way that is compatible with the host's light/dark color variables 
 
-Example CSS:
+Example usage of standardized CSS variables:
 
 ```css
 .container {
-  background: var(--color-background-primary, #ffffff);
-  color: var(--color-text-primary, #171717);
-  font: var(--font-style-body, 400 16px/1.4 system-ui);
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  font: var(--font-style-body);
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds documentation for the `styles` field introduced in #127 to the MCP Apps specification (SEP-1865).

- Add `styles` field to `HostContext` interface
- Add dedicated **Theming** section documenting all 36 standardized CSS variables
- Document Host/App behavior including `light-dark()` usage
- Add Design Decision #4 in Rationale section explaining the approach

## Changes

### HostContext Interface
- New `styles?: Record<string, string>` field with reference to Theming section

### Theming Section
- Table of 36 CSS variables organized by category (colors, typography, borders)
- Host Behavior: MAY provide any subset, MAY use `light-dark()`
- App Behavior: SHOULD use fallbacks, MUST set `color-scheme` when using `light-dark()` values

### Rationale
- Design Decision #4 explains why CSS variables, limited set, no spacing, no component library

🤖 Generated with [Claude Code](https://claude.com/claude-code)