### PR TITLE
docs: typo and formatting issues in spec header

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -1,8 +1,11 @@
 # SEP-1865: MCP Apps: Interactive User Interfaces for MCP
 
 **Track:** Extensions
-**Authors:** Ido Salomon, Liad Yosef, Olivier Chafik, Jerome Swannack, Jonathan Hefner, Anton Pidkuiko, Nick Cooper, Bryan Ashley, Alexei Christakis
+
+**Authors:** Ido Salomon, Liad Yosef, Olivier Chafik, Jerome Swannack, Jonathan Hefner, Anton Pidkuiko, Nick Cooper, Bryan Ashley, Alexi Christakis
+
 **Status:** Draft
+
 **Created:** 2025-11-21
 
 ## Abstract


### PR DESCRIPTION
1. Fix typo in Alexi's name
2. Format the header so the fields won't be in the same line