### PR TITLE
Mark `src/generated` as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 package-lock.json linguist-generated=true
+src/generated/** linguist-generated=true


### PR DESCRIPTION
Files in `src/generated/` are produced by `scripts/generate-schemas.ts` and should be collapsed by default in PR diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
