### PR TITLE
Fix sandbox-proxy-ready notification name in spec

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -358,7 +358,7 @@ If the Host is a web page, it MUST wrap the Guest UI and communicate with it thr
 
 1. The Host and the Sandbox MUST have different origins.
 2. The Sandbox MUST have the following permissions: `allow-scripts`, `allow-same-origin`.
-3. The Sandbox MUST send a `ui/notifications/sandbox-ready` notification to the host when it’s ready to process an `ui/sandbox-resource-ready` notification.
+3. The Sandbox MUST send a `ui/notifications/sandbox-proxy-ready` notification to the host when it's ready to process an `ui/notifications/sandbox-resource-ready` notification.
 4. Once the Sandbox is ready, the Host MUST send the raw HTML resource to load in a `ui/notifications/sandbox-resource-ready` notification.
 5. The Sandbox MUST load the raw HTML of the Guest UI with CSP settings that:
    - Enforce the domains declared in `ui.csp` metadata
@@ -841,12 +841,12 @@ Host MAY send this notification when any context field changes (e.g., theme togg
 
 These messages are reserved for web-based hosts that implement the recommended double-iframe sandbox architecture:
 
-`ui/notifications/sandbox-ready` (Sandbox Proxy → Host) - Sandbox proxy is ready
+`ui/notifications/sandbox-proxy-ready` (Sandbox Proxy → Host) - Sandbox proxy is ready
 
 ```typescript
 {
   jsonrpc: "2.0",
-  method: "ui/notifications/sandbox-ready",
+  method: "ui/notifications/sandbox-proxy-ready",
   params: {}
 }
 ```
@@ -899,7 +899,7 @@ sequenceDiagram
       H ->> H: Render Guest UI in an iframe (HTML from the ui:// resource)
     else Web hosts
       H ->> H: Render Sandbox Proxy in an iframe (different origin)
-      P ->> H: ui/notifications/sandbox-ready
+      P ->> H: ui/notifications/sandbox-proxy-ready
       H -->> P: ui/notifications/sandbox-resource-ready (HTML content)
       P -> P: Render inner iframe with HTML
 


### PR DESCRIPTION
## Summary
- Fixes discrepancy between the spec and implementation for sandbox proxy notification method name
- Updates spec from `ui/notifications/sandbox-ready` to `ui/notifications/sandbox-proxy-ready` to match the implementation
- Also fixes a typo: `ui/sandbox-resource-ready` → `ui/notifications/sandbox-resource-ready`

## Test plan
- [x] Verified no more `sandbox-ready` (without `proxy-`) references in the spec
- [x] Build and prettier checks pass

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)