### PR TITLE
fix: make react a peer dependency to support multiple versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,7 @@
       ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.3",
-        "prettier": "^3.6.2",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "prettier": "^3.6.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.52.0",
@@ -30,6 +28,8 @@
         "express": "^5.1.0",
         "husky": "^9.1.7",
         "nodemon": "^3.1.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
         "ts-to-zod": "^5.1.0",
         "tsx": "^4.21.0",
         "typedoc": "^0.28.14",
@@ -55,7 +55,17 @@
         "@rollup/rollup-win32-x64-msvc": "^4.53.3"
       },
       "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "examples/basic-host": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "@types/bun": "^1.3.2",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "concurrently": "^9.2.1",
     "cors": "^2.8.5",
     "cross-env": "^10.1.0",
@@ -73,13 +75,21 @@
     "zod": "^4.1.13"
   },
   "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "zod": "^3.25.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.24.3",
-    "prettier": "^3.6.2",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "prettier": "^3.6.2"
   },
   "optionalDependencies": {
     "@oven/bun-darwin-aarch64": "^1.3.4",


### PR DESCRIPTION
## Summary

- Move `react` and `react-dom` from `dependencies` to `peerDependencies` with support for React 17, 18, and 19
- Mark react dependencies as optional in `peerDependenciesMeta` (only `/react` subpath needs them)
- Keep `react` and `react-dom` in `devDependencies` for local development/testing

Fixes #163

## Test plan

- [x] `npm install` succeeds
- [x] `npm test` passes (33 tests)
- [x] `npm run build:all` succeeds (all examples build)
- [ ] Verify consumers can use React 17/18/19 with the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)