### PR TITLE
Add npm `start` alias for `examples:start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To run all examples together:
 
 ```bash
 npm install
-npm run examples:start
+npm start
 ```
 
 Then open http://localhost:8080/.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   ],
   "scripts": {
     "postinstall": "node scripts/setup-bun.mjs || echo 'setup-bun.mjs failed or not available'",
+    "start": "npm run examples:start",
     "generate:schemas": "tsx scripts/generate-schemas.ts && prettier --write \"src/generated/**/*\"",
     "build": "npm run generate:schemas && node scripts/run-bun.mjs build.bun.ts",
     "prepack": "npm run build",


### PR DESCRIPTION
Allows running `npm start` as a shorthand for `npm run examples:start`, providing a conventional entry point to launch the example servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
