### PR TITLE
spec: remove Intents reference from rationale

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -1540,7 +1540,7 @@ This proposal synthesizes feedback from the UI CWG and MCP-UI community, host im
 
 **Alternatives considered:**
 
-- **Custom message protocol:** Current MCP-UI approach with message types like tool, intent, prompt, etc. These message types can be translated to a subset of the proposed JSON-RPC messages.
+- **Custom message protocol:** Current MCP-UI approach with message types like tool, prompt, etc. These message types can be translated to a subset of the proposed JSON-RPC messages.
 - **Global API object:** Rejected because it requires host-specific injection and doesn't work with external iframe sources. Syntactic sugar may still be added on the server/UI side.
 
 #### 3. Support Raw HTML Content Type


### PR DESCRIPTION
## Summary

Remove "intent" from the list of MCP-UI message types in the rationale section (Intents concept was dropped in earlier discussions).

## Changes

| Location | Change |
|----------|--------|
| Line ~1543 (Rationale) | Removed "intent" from `"tool, intent, prompt, etc."` |

**Note:** The original "Notify → Log" rename is now moot since PR #125 updated the lifecycle diagram with the new `ui/update-model-context` message and renamed "Notify" to "Log".

## Test plan

- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)