### PR TITLE
docs: fix tsc command to use tsconfig.json

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -180,7 +180,7 @@ app.listen(3001, (err) => {
 Then, verify your server compiles:
 
 ```bash
-npx tsc --noEmit server.ts
+npx tsc --noEmit
 ```
 
 No output means success. If you see errors, check for typos in `server.ts`.


### PR DESCRIPTION


## Problem

I went through the quickstart. Amazing job. I ran into one quick problem. The quickstart docs instruct users to run:

```bash
npx tsc --noEmit server.ts
```

When a file is specified directly, TypeScript **ignores tsconfig.json entirely**, causing `skipLibCheck` and other options to not apply. This results in a flood of errors from `node_modules` (especially zod v4 locale files).

## Solution

Remove the `server.ts` argument:

```bash
npx tsc --noEmit
```

This lets tsc use the project's tsconfig.json settings, which includes `skipLibCheck: true`.
