### PR TITLE
fix: defer initial size measurement to ResizeObserver

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -979,8 +979,7 @@ export class App extends Protocol<AppRequest, AppNotification, AppResult> {
       });
     };
 
-    sendBodySizeChanged();
-
+    // ResizeObserver will fire for initial layout and all subsequent changes
     const resizeObserver = new ResizeObserver(sendBodySizeChanged);
     // Observe both html and body to catch all size changes
     resizeObserver.observe(document.documentElement);


### PR DESCRIPTION
Fixes #143

## Problem

`setupSizeChangedNotifications()` was measuring DOM size immediately after `connect()`, before async content (maps, data fetches) could load. This caused widgets to report their loading spinner height (~110px) instead of final content height, resulting in clipped content.

### Reproduction Flow
1. Widget connects and displays loading spinner
2. SDK immediately measures height (~110px for spinner only)
3. Host resizes iframe to match reported dimensions
4. Async content loads but container remains constrained
5. Content renders clipped due to insufficient space

## Solution

Remove the immediate `sendBodySizeChanged()` call and rely purely on `ResizeObserver`, which fires when content actually renders and changes size.

### Before (line 982)
```typescript
sendBodySizeChanged();  // Immediate measurement - PROBLEM

const resizeObserver = new ResizeObserver(sendBodySizeChanged);
```

### After
```typescript
// ResizeObserver will fire for initial layout and all subsequent changes
const resizeObserver = new ResizeObserver(sendBodySizeChanged);
```

## Why This Works

1. `ResizeObserver` already monitors `document.documentElement` and `document.body`
2. It fires on initial render AND subsequent size changes
3. Async content triggers `ResizeObserver` when it loads
4. Minimal code change (1 line removed)
5. Fully backward compatible

## Testing

- [x] Unit tests pass (`npm test`)
- [x] E2E tests pass (`npm run test:e2e`)
- [x] Prettier formatting passes