### PR TITLE
fix: make example host more resilient to broken servers

### DIFF
--- a/examples/threejs-server/src/threejs-app.tsx
+++ b/examples/threejs-server/src/threejs-app.tsx
@@ -172,6 +172,7 @@ export default function ThreeJSApp({
   return (
     <div ref={containerRef} className="threejs-container">
       <canvas
+        id="threejs-canvas"
         ref={canvasRef}
         style={{
           width: "100%",

--- a/tests/e2e/servers.spec.ts
+++ b/tests/e2e/servers.spec.ts
@@ -17,7 +17,7 @@ const DYNAMIC_MASKS: Record<string, string[]> = {
     "#memory-bar-fill", // Memory bar fill level
     "#info-uptime", // System uptime
   ],
-  threejs: ["canvas"], // 3D render canvas (dynamic animation)
+  threejs: ["#threejs-canvas", ".threejs-container"], // 3D render canvas (dynamic animation)
   "wiki-explorer": ["#graph"], // Force-directed graph (dynamic layout)
 };
 


### PR DESCRIPTION
## Summary

Fixes E2E test flakiness and improves host resilience to server connection failures.

### Changes

1. **basic-host: Be resilient to individual server connection failures**
   - Use `Promise.allSettled` instead of `Promise.all`
   - Failed connections are logged as warnings but don't crash the UI
   - Only throws if ALL servers fail to connect

2. **threejs-server: Add id to canvas for reliable screenshot masking**
   - Added `id="threejs-canvas"` to the canvas element
   - Updated e2e test masks to use `#threejs-canvas` and `.threejs-container`
   - Fixes flaky Three.js screenshot comparisons in CI

## Test plan

- [ ] Run `npm run examples:start`, stop one server, verify UI continues working
- [ ] Run E2E tests: `npm run test:e2e:docker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)