### PR TITLE
fix: make toolInfo.id optional per spec

### DIFF
--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -248,7 +248,7 @@
                   "additionalProperties": false
                 }
               },
-              "required": ["id", "tool"],
+              "required": ["tool"],
               "additionalProperties": false
             },
             "theme": {
@@ -919,7 +919,7 @@
               "additionalProperties": false
             }
           },
-          "required": ["id", "tool"],
+          "required": ["tool"],
           "additionalProperties": false
         },
         "theme": {
@@ -2127,7 +2127,7 @@
                   "additionalProperties": false
                 }
               },
-              "required": ["id", "tool"],
+              "required": ["tool"],
               "additionalProperties": false
             },
             "theme": {

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -539,7 +539,9 @@ export const McpUiHostContextSchema = z
     toolInfo: z
       .object({
         /** @description JSON-RPC id of the tools/call request. */
-        id: RequestIdSchema.describe("JSON-RPC id of the tools/call request."),
+        id: RequestIdSchema.optional().describe(
+          "JSON-RPC id of the tools/call request.",
+        ),
         /** @description Tool definition including name, inputSchema, etc. */
         tool: ToolSchema.describe(
           "Tool definition including name, inputSchema, etc.",

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -313,7 +313,7 @@ export interface McpUiHostContext {
   /** @description Metadata of the tool call that instantiated this App. */
   toolInfo?: {
     /** @description JSON-RPC id of the tools/call request. */
-    id: RequestId;
+    id?: RequestId;
     /** @description Tool definition including name, inputSchema, etc. */
     tool: Tool;
   };


### PR DESCRIPTION
## Summary

Aligns the TypeScript types and generated Zod schemas with the specification.

## Changes

The **spec (apps.mdx line 444)** defines `toolInfo.id` as **optional**:

```typescript
toolInfo?: {
  id?: RequestId,  // <-- optional in spec
  tool: Tool,
};
```

However, the implementation had it as required. This PR fixes the mismatch.

## Why this matters

This allows hosts to pass just the tool definition without needing a request ID, which is useful when the widget only needs to know which tool was called (e.g., for custom loading screens per tool type).