### PR TITLE
Refactor server start in examples

### DIFF
--- a/examples/basic-server-preact/server-utils.ts
+++ b/examples/basic-server-preact/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/basic-server-preact/server.ts
+++ b/examples/basic-server-preact/server.ts
@@ -1,10 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { registerAppTool, registerAppResource, RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -57,12 +56,9 @@ function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3001", 10);
-    await startServer(createServer, { port, name: "Basic MCP App Server (Preact)" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/basic-server-react/server-utils.ts
+++ b/examples/basic-server-react/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/basic-server-react/server.ts
+++ b/examples/basic-server-react/server.ts
@@ -1,10 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { registerAppTool, registerAppResource, RESOURCE_MIME_TYPE, RESOURCE_URI_META_KEY } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -48,12 +47,9 @@ export function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3001", 10);
-    await startServer(createServer, { port, name: "Basic MCP App Server (React)" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/basic-server-solid/server-utils.ts
+++ b/examples/basic-server-solid/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/basic-server-solid/server.ts
+++ b/examples/basic-server-solid/server.ts
@@ -1,10 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { registerAppTool, registerAppResource, RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -57,12 +56,9 @@ function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3001", 10);
-    await startServer(createServer, { port, name: "Basic MCP App Server (Solid)" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/basic-server-svelte/server-utils.ts
+++ b/examples/basic-server-svelte/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/basic-server-svelte/server.ts
+++ b/examples/basic-server-svelte/server.ts
@@ -1,10 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { registerAppTool, registerAppResource, RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -57,12 +56,9 @@ function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3001", 10);
-    await startServer(createServer, { port, name: "Basic MCP App Server (Svelte)" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/basic-server-vanillajs/server-utils.ts
+++ b/examples/basic-server-vanillajs/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/basic-server-vanillajs/server.ts
+++ b/examples/basic-server-vanillajs/server.ts
@@ -1,10 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { registerAppTool, registerAppResource, RESOURCE_MIME_TYPE, RESOURCE_URI_META_KEY } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 const RESOURCE_URI = "ui://get-time/mcp-app.html";
@@ -59,12 +58,9 @@ export function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3102", 10);
-    await startServer(createServer, { port, name: "Basic MCP App Server (Vanilla JS)" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/basic-server-vue/server-utils.ts
+++ b/examples/basic-server-vue/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/basic-server-vue/server.ts
+++ b/examples/basic-server-vue/server.ts
@@ -1,10 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { registerAppTool, registerAppResource, RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -57,12 +56,9 @@ function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3001", 10);
-    await startServer(createServer, { port, name: "Basic MCP App Server (Vue)" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/budget-allocator-server/server-utils.ts
+++ b/examples/budget-allocator-server/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/budget-allocator-server/server.ts
+++ b/examples/budget-allocator-server/server.ts
@@ -5,7 +5,6 @@
  * and industry benchmarks by company stage.
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type {
   CallToolResult,
   ReadResourceResult,
@@ -19,7 +18,7 @@ import {
   registerAppResource,
   registerAppTool,
 } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -312,12 +311,9 @@ export function createServer(): McpServer {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3103", 10);
-    await startServer(createServer, { port, name: "Budget Allocator Server" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/cohort-heatmap-server/server-utils.ts
+++ b/examples/cohort-heatmap-server/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/cohort-heatmap-server/server.ts
+++ b/examples/cohort-heatmap-server/server.ts
@@ -1,5 +1,4 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -10,7 +9,7 @@ import {
   registerAppResource,
   registerAppTool,
 } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -212,12 +211,9 @@ export function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3104", 10);
-    await startServer(createServer, { port, name: "Cohort Heatmap Server" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/customer-segmentation-server/server-utils.ts
+++ b/examples/customer-segmentation-server/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/customer-segmentation-server/server.ts
+++ b/examples/customer-segmentation-server/server.ts
@@ -1,5 +1,4 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type {
   CallToolResult,
   ReadResourceResult,
@@ -13,7 +12,7 @@ import {
   registerAppResource,
   registerAppTool,
 } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 import {
   generateCustomers,
   generateSegmentSummaries,
@@ -120,15 +119,9 @@ export function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3105", 10);
-    await startServer(createServer, {
-      port,
-      name: "Customer Segmentation Server",
-    });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/integration-server/server-utils.ts
+++ b/examples/integration-server/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/integration-server/server.ts
+++ b/examples/integration-server/server.ts
@@ -1,5 +1,4 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type {
   CallToolResult,
   ReadResourceResult,
@@ -12,7 +11,7 @@ import {
   RESOURCE_MIME_TYPE,
   RESOURCE_URI_META_KEY,
 } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 const RESOURCE_URI = "ui://get-time/mcp-app.html";
@@ -69,12 +68,9 @@ export function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3001", 10);
-    await startServer(createServer, { port, name: "Integration Test Server" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/scenario-modeler-server/server-utils.ts
+++ b/examples/scenario-modeler-server/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/scenario-modeler-server/server.ts
+++ b/examples/scenario-modeler-server/server.ts
@@ -1,5 +1,4 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type {
   CallToolResult,
   ReadResourceResult,
@@ -13,7 +12,7 @@ import {
   registerAppResource,
   registerAppTool,
 } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -325,15 +324,9 @@ export function createServer(): McpServer {
 // ============================================================================
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3106", 10);
-    await startServer(createServer, {
-      port,
-      name: "SaaS Scenario Modeler Server",
-    });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/sheet-music-server/server-utils.ts
+++ b/examples/sheet-music-server/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/sheet-music-server/server.ts
+++ b/examples/sheet-music-server/server.ts
@@ -13,8 +13,7 @@ import {
   registerAppResource,
   registerAppTool,
 } from "@modelcontextprotocol/ext-apps/server";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -118,12 +117,9 @@ function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3001", 10);
-    await startServer(createServer, { port, name: "Sheet Music Server" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/system-monitor-server/server-utils.ts
+++ b/examples/system-monitor-server/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/system-monitor-server/server.ts
+++ b/examples/system-monitor-server/server.ts
@@ -1,5 +1,4 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type {
   CallToolResult,
   ReadResourceResult,
@@ -15,7 +14,7 @@ import {
   registerAppResource,
   registerAppTool,
 } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 // Schemas - types are derived from these using z.infer
 const CpuCoreSchema = z.object({
@@ -182,12 +181,9 @@ export function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3107", 10);
-    await startServer(createServer, { port, name: "System Monitor Server" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/threejs-server/server-utils.ts
+++ b/examples/threejs-server/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/threejs-server/server.ts
+++ b/examples/threejs-server/server.ts
@@ -4,7 +4,6 @@
  * Provides tools for rendering interactive 3D scenes using Three.js.
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -15,7 +14,7 @@ import {
   registerAppResource,
   registerAppTool,
 } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -224,12 +223,9 @@ export function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3108", 10);
-    await startServer(createServer, { port, name: "Three.js Server" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/video-resource-server/server-utils.ts
+++ b/examples/video-resource-server/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/video-resource-server/server.ts
+++ b/examples/video-resource-server/server.ts
@@ -21,8 +21,7 @@ import {
   RESOURCE_MIME_TYPE,
   RESOURCE_URI_META_KEY,
 } from "@modelcontextprotocol/ext-apps/server";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 const RESOURCE_URI = "ui://video-player/mcp-app.html";
@@ -170,12 +169,9 @@ ${Object.entries(VIDEO_LIBRARY)
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3001", 10);
-    await startServer(createServer, { port, name: "Video Resource Server" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {

--- a/examples/wiki-explorer-server/server-utils.ts
+++ b/examples/wiki-explorer-server/server-utils.ts
@@ -1,29 +1,34 @@
 /**
- * Shared utilities for running MCP servers with Streamable HTTP transport.
+ * Shared utilities for running MCP servers with various transports.
  */
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import cors from "cors";
 import type { Request, Response } from "express";
 
-export interface ServerOptions {
-  port: number;
-  name?: string;
+/**
+ * Starts an MCP server with stdio transport.
+ *
+ * @param createServer - Factory function that creates a new McpServer instance.
+ */
+export async function startStdioServer(
+  createServer: () => McpServer,
+): Promise<void> {
+  await createServer().connect(new StdioServerTransport());
 }
 
 /**
  * Starts an MCP server with Streamable HTTP transport in stateless mode.
  *
  * @param createServer - Factory function that creates a new McpServer instance per request.
- * @param options - Server configuration options.
  */
-export async function startServer(
+export async function startHttpServer(
   createServer: () => McpServer,
-  options: ServerOptions,
 ): Promise<void> {
-  const { port, name = "MCP Server" } = options;
+  const port = parseInt(process.env.PORT ?? "3001", 10);
 
   const app = createMcpExpressApp({ host: "0.0.0.0" });
   app.use(cors());
@@ -55,7 +60,7 @@ export async function startServer(
   });
 
   const httpServer = app.listen(port, () => {
-    console.log(`${name} listening on http://localhost:${port}/mcp`);
+    console.log(`Server listening on http://localhost:${port}/mcp`);
   });
 
   const shutdown = () => {

--- a/examples/wiki-explorer-server/server.ts
+++ b/examples/wiki-explorer-server/server.ts
@@ -1,5 +1,4 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type {
   CallToolResult,
   ReadResourceResult,
@@ -14,7 +13,7 @@ import {
   registerAppResource,
   registerAppTool,
 } from "@modelcontextprotocol/ext-apps/server";
-import { startServer } from "./server-utils.js";
+import { startStdioServer, startHttpServer } from "./server-utils.js";
 
 const DIST_DIR = path.join(import.meta.dirname, "dist");
 
@@ -153,12 +152,9 @@ export function createServer(): McpServer {
 }
 
 async function main() {
-  if (process.argv.includes("--stdio")) {
-    await createServer().connect(new StdioServerTransport());
-  } else {
-    const port = parseInt(process.env.PORT ?? "3109", 10);
-    await startServer(createServer, { port, name: "Wiki Explorer" });
-  }
+  process.argv.includes("--stdio")
+    ? await startStdioServer(createServer)
+    : await startHttpServer(createServer);
 }
 
 main().catch((e) => {


### PR DESCRIPTION
Split server startup logic into two functions in each `server-utils.ts`:

- `startStdioServer(createServer)` - handles stdio transport
- `startHttpServer(createServer)` - handles HTTP transport

And keep the transport selection visible in each `server.ts`:

```typescript
process.argv.includes("--stdio")
  ? await startStdioServer(createServer)
  : await startHttpServer(createServer);
```
