### PR TITLE
Replace client capability negotiation from `extensions` to `experimental`

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -1252,7 +1252,7 @@ Clients advertise MCP Apps support in the initialize request using the extension
   "params": {
     "protocolVersion": "2024-11-05",
     "capabilities": {
-      "extensions": {
+      "experimental": {
         "io.modelcontextprotocol/ui": {
           "mimeTypes": ["text/html;profile=mcp-app"]
         }
@@ -1281,7 +1281,7 @@ Servers SHOULD check client (host would-be) capabilities before registering UI-e
 
 ```typescript
 const hasUISupport =
-  clientCapabilities?.extensions?.["io.modelcontextprotocol/ui"]?.mimeTypes?.includes("text/html;profile=mcp-app");
+  clientCapabilities?.experimental?.["io.modelcontextprotocol/ui"]?.mimeTypes?.includes("text/html;profile=mcp-app");
 
 if (hasUISupport) {
   // Register tools with UI templates


### PR DESCRIPTION
Replace `clientCapabilities?.extensions` with `clientCapabilities?.experimental`. See https://github.com/modelcontextprotocol/ext-apps/issues/231

## Motivation and Context
See https://github.com/modelcontextprotocol/ext-apps/issues/231

## How Has This Been Tested?
This is just changing a .mdx doc

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
