### PR TITLE
fix: add error handling for server startup failures

### DIFF
--- a/examples/basic-server-preact/server-utils.ts
+++ b/examples/basic-server-preact/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/basic-server-react/server-utils.ts
+++ b/examples/basic-server-react/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/basic-server-solid/server-utils.ts
+++ b/examples/basic-server-solid/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/basic-server-svelte/server-utils.ts
+++ b/examples/basic-server-svelte/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/basic-server-vanillajs/server-utils.ts
+++ b/examples/basic-server-vanillajs/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/basic-server-vue/server-utils.ts
+++ b/examples/basic-server-vue/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/budget-allocator-server/server-utils.ts
+++ b/examples/budget-allocator-server/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/cohort-heatmap-server/server-utils.ts
+++ b/examples/cohort-heatmap-server/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/customer-segmentation-server/server-utils.ts
+++ b/examples/customer-segmentation-server/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/integration-server/server-utils.ts
+++ b/examples/integration-server/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/scenario-modeler-server/server-utils.ts
+++ b/examples/scenario-modeler-server/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/sheet-music-server/server-utils.ts
+++ b/examples/sheet-music-server/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/system-monitor-server/server-utils.ts
+++ b/examples/system-monitor-server/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/threejs-server/server-utils.ts
+++ b/examples/threejs-server/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/video-resource-server/server-utils.ts
+++ b/examples/video-resource-server/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 

--- a/examples/wiki-explorer-server/server-utils.ts
+++ b/examples/wiki-explorer-server/server-utils.ts
@@ -54,7 +54,11 @@ export async function startServer(
     }
   });
 
-  const httpServer = app.listen(port, () => {
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
     console.log(`${name} listening on http://localhost:${port}/mcp`);
   });
 


### PR DESCRIPTION
## Summary
- Add error handling to `app.listen()` callback in all example server-utils.ts files
- Previously, if the server failed to start (e.g., port already in use), it would fail silently
- Now logs the error and exits with non-zero status code for proper failure visibility

## Test plan
- [ ] Start a server on a port
- [ ] Try to start another server on the same port
- [ ] Verify error is logged and process exits with code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)