### PR TITLE
fix(qr-server): Update SDK to 0.3.1 with app-with-deps bundle

### DIFF
--- a/examples/qr-server/widget.html
+++ b/examples/qr-server/widget.html
@@ -27,7 +27,7 @@
 <body>
   <div id="qr"></div>
   <script type="module">
-    import { App, PostMessageTransport } from "https://unpkg.com/@modelcontextprotocol/ext-apps@0.0.1";
+    import { App } from "https://unpkg.com/@modelcontextprotocol/ext-apps@0.3.1/app-with-deps";
 
     const app = new App({ name: "QR Widget", version: "1.0.0" });
 


### PR DESCRIPTION
## Summary

Update the qr-server example widget to use the latest SDK version (0.3.1) with the `app-with-deps` bundle export.

## Changes

- Use `app-with-deps` export for CDN imports (includes all dependencies bundled)

## Problem

The previous import from `@0.0.1` was outdated and the regular import from newer versions fails in browser because unpkg can't resolve npm dependencies (Zod, MCP SDK, etc.).

## Solution

The `app-with-deps` export provides a self-contained bundle with all dependencies included, specifically designed for CDN/browser usage.

## Testing

Tested on Claude Nest - QR code widget now loads and works correctly.