### PR TITLE
revert to document.write again; cesiumjs doesn't like srcdoc, period.

### DIFF
--- a/examples/map-server/server.ts
+++ b/examples/map-server/server.ts
@@ -89,7 +89,7 @@ async function geocodeWithNominatim(query: string): Promise<NominatimResult[]> {
  */
 export function createServer(): McpServer {
   const server = new McpServer({
-    name: "Map Server",
+    name: "CesiumJS Map Server",
     version: "1.0.0",
   });
 


### PR DESCRIPTION
FIt of flip-flopping on this (cf. https://github.com/modelcontextprotocol/ext-apps/pull/248), but w/ https://github.com/modelcontextprotocol/ext-apps/pull/246 making it a lot easier to test changes quickly, I can confirm a mysterious issue w/ the Map demo + srcdoc.

document.write should be equivalent in terms of origins / security so reverting to using it when possible.