### PR TITLE
Use `Tool` as the input type in `getToolUiResourceUri`

### DIFF
--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -31,6 +31,7 @@ import {
   ReadResourceResultSchema,
   ResourceListChangedNotification,
   ResourceListChangedNotificationSchema,
+  Tool,
   ToolListChangedNotification,
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -107,9 +108,7 @@ export { PostMessageTransport } from "./message-transport";
  * });
  * ```
  */
-export function getToolUiResourceUri(tool: {
-  _meta?: Record<string, unknown>;
-}): string | undefined {
+export function getToolUiResourceUri(tool: Partial<Tool>): string | undefined {
   // Try new nested format first: _meta.ui.resourceUri
   const uiMeta = tool._meta?.ui as { resourceUri?: unknown } | undefined;
   let uri: unknown = uiMeta?.resourceUri;


### PR DESCRIPTION
We replace the use of the raw type with `Partial<Tool>` type from the MCP Typescript SDK 

## Motivation and Context
The function name `getToolUiResourceUri` implies that the input value is a `Tool`. The type should reflect such input. This allows people to input the entire Tool result into the function, rather than having to extract the tool `_meta` themselves and passing it into the function. 

I set it to `Partial` to be backwards compatible with those who are currently inputting the `_meta` raw. 

## How Has This Been Tested?
Test cases pass. 

## Breaking Changes
Not breaking. Using `Partial` 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed
