### PR TITLE
feat(shadertoy): show fullscreen button only on widget hover

### DIFF
--- a/examples/shadertoy-server/src/mcp-app.css
+++ b/examples/shadertoy-server/src/mcp-app.css
@@ -2,6 +2,7 @@ html, body {
   margin: 0;
   width: 100%;
   height: 100%;
+  min-height: 400px;
   overflow: hidden;
 }
 
@@ -9,6 +10,7 @@ html, body {
   position: relative;
   width: 100%;
   height: 100%;
+  min-height: 400px;
 }
 
 #canvas {
@@ -33,7 +35,7 @@ html, body {
   align-items: center;
   justify-content: center;
   transition: background 0.2s, opacity 0.2s;
-  opacity: 0.7;
+  opacity: 0; /* Initially invisible, shown on widget hover */
   z-index: 100;
 }
 
@@ -53,6 +55,11 @@ html, body {
 
 .fullscreen-btn.available {
   display: flex;
+}
+
+/* Show button on widget hover */
+.main:hover .fullscreen-btn.available {
+  opacity: 0.7;
 }
 
 /* Fullscreen mode */


### PR DESCRIPTION
Shows the fullscreen button only when hovering over the widget, as suggested in #278.

Changes:
- Set button `opacity: 0` by default
- Add `.main:hover .fullscreen-btn.available { opacity: 0.7 }` to reveal on hover
- Button still becomes fully opaque when directly hovered