### PR TITLE
Add `isToolVisibilityModelOnly` and `isToolVisibilityAppOnly` helper functions

### DIFF
--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -17,6 +17,8 @@ import { App } from "./app";
 import {
   AppBridge,
   getToolUiResourceUri,
+  isToolVisibilityModelOnly,
+  isToolVisibilityAppOnly,
   type McpUiHostCapabilities,
 } from "./app-bridge";
 
@@ -918,6 +920,156 @@ describe("getToolUiResourceUri", () => {
       expect(() => getToolUiResourceUri(tool)).toThrow(
         "Invalid UI resource URI",
       );
+    });
+  });
+});
+
+describe("isToolVisibilityModelOnly", () => {
+  describe("returns true", () => {
+    it("when visibility is exactly ['model']", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { visibility: ["model"] } },
+      };
+      expect(isToolVisibilityModelOnly(tool)).toBe(true);
+    });
+  });
+
+  describe("returns false", () => {
+    it("when visibility is ['app']", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { visibility: ["app"] } },
+      };
+      expect(isToolVisibilityModelOnly(tool)).toBe(false);
+    });
+
+    it("when visibility is ['model', 'app']", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { visibility: ["model", "app"] } },
+      };
+      expect(isToolVisibilityModelOnly(tool)).toBe(false);
+    });
+
+    it("when visibility is ['app', 'model']", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { visibility: ["app", "model"] } },
+      };
+      expect(isToolVisibilityModelOnly(tool)).toBe(false);
+    });
+
+    it("when visibility is empty array", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { visibility: [] } },
+      };
+      expect(isToolVisibilityModelOnly(tool)).toBe(false);
+    });
+
+    it("when visibility is undefined", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: {} },
+      };
+      expect(isToolVisibilityModelOnly(tool)).toBe(false);
+    });
+
+    it("when _meta.ui is missing", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: {},
+      };
+      expect(isToolVisibilityModelOnly(tool)).toBe(false);
+    });
+
+    it("when _meta is missing", () => {
+      const tool = { name: "test-tool" };
+      expect(isToolVisibilityModelOnly(tool)).toBe(false);
+    });
+
+    it("when tool has resourceUri but no visibility", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { resourceUri: "ui://server/app.html" } },
+      };
+      expect(isToolVisibilityModelOnly(tool)).toBe(false);
+    });
+  });
+});
+
+describe("isToolVisibilityAppOnly", () => {
+  describe("returns true", () => {
+    it("when visibility is exactly ['app']", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { visibility: ["app"] } },
+      };
+      expect(isToolVisibilityAppOnly(tool)).toBe(true);
+    });
+  });
+
+  describe("returns false", () => {
+    it("when visibility is ['model']", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { visibility: ["model"] } },
+      };
+      expect(isToolVisibilityAppOnly(tool)).toBe(false);
+    });
+
+    it("when visibility is ['model', 'app']", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { visibility: ["model", "app"] } },
+      };
+      expect(isToolVisibilityAppOnly(tool)).toBe(false);
+    });
+
+    it("when visibility is ['app', 'model']", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { visibility: ["app", "model"] } },
+      };
+      expect(isToolVisibilityAppOnly(tool)).toBe(false);
+    });
+
+    it("when visibility is empty array", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { visibility: [] } },
+      };
+      expect(isToolVisibilityAppOnly(tool)).toBe(false);
+    });
+
+    it("when visibility is undefined", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: {} },
+      };
+      expect(isToolVisibilityAppOnly(tool)).toBe(false);
+    });
+
+    it("when _meta.ui is missing", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: {},
+      };
+      expect(isToolVisibilityAppOnly(tool)).toBe(false);
+    });
+
+    it("when _meta is missing", () => {
+      const tool = { name: "test-tool" };
+      expect(isToolVisibilityAppOnly(tool)).toBe(false);
+    });
+
+    it("when tool has resourceUri but no visibility", () => {
+      const tool = {
+        name: "test-tool",
+        _meta: { ui: { resourceUri: "ui://server/app.html" } },
+      };
+      expect(isToolVisibilityAppOnly(tool)).toBe(false);
     });
   });
 });

--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -78,6 +78,7 @@ import {
   McpUiRequestDisplayModeRequestSchema,
   McpUiRequestDisplayModeResult,
   McpUiResourcePermissions,
+  McpUiToolMeta,
 } from "./types";
 export * from "./types";
 export { RESOURCE_URI_META_KEY, RESOURCE_MIME_TYPE } from "./app";
@@ -110,7 +111,7 @@ export { PostMessageTransport } from "./message-transport";
  */
 export function getToolUiResourceUri(tool: Partial<Tool>): string | undefined {
   // Try new nested format first: _meta.ui.resourceUri
-  const uiMeta = tool._meta?.ui as { resourceUri?: unknown } | undefined;
+  const uiMeta = tool._meta?.ui as McpUiToolMeta | undefined;
   let uri: unknown = uiMeta?.resourceUri;
 
   // Fall back to deprecated flat format: _meta["ui/resourceUri"]
@@ -124,6 +125,34 @@ export function getToolUiResourceUri(tool: Partial<Tool>): string | undefined {
     throw new Error(`Invalid UI resource URI: ${JSON.stringify(uri)}`);
   }
   return undefined;
+}
+
+/**
+ * Check if a tool is visible to the model only.
+ *
+ * @param tool - Tool object with visibility metadata
+ * @returns True if the tool is visible to the model only, false otherwise
+ */
+export function isToolVisibilityModelOnly(tool: Partial<Tool>): boolean {
+  const uiMeta = tool._meta?.ui as McpUiToolMeta | undefined;
+  const visibility = uiMeta?.visibility as Array<"model" | "app"> | undefined;
+  if (!visibility) return false;
+  if (visibility.length === 1 && visibility[0] === "model") return true;
+  return false;
+}
+
+/**
+ * Check if a tool is visible to the app only.
+ *
+ * @param tool - Tool object with visibility metadata
+ * @returns True if the tool is visible to the app only, false otherwise
+ */
+export function isToolVisibilityAppOnly(tool: Partial<Tool>): boolean {
+  const uiMeta = tool._meta?.ui as McpUiToolMeta | undefined;
+  const visibility = uiMeta?.visibility as Array<"model" | "app"> | undefined;
+  if (!visibility) return false;
+  if (visibility.length === 1 && visibility[0] === "app") return true;
+  return false;
 }
 
 /**


### PR DESCRIPTION
We create two helper functions `isToolVisibilityModelOnly` and `isToolVisibilityAppOnly` that checks for a Tool's visibility metadata. 

This is helpful for client developers to check tool visibility. 

## Motivation and Context
We create an easy way to check a tool's visibility. These functions are a good abstraction: 
1. More descriptive than `["app"]` and `["model"]`. 
2. Takes in a common `Tool` object. Developer doesn't have to remember where visibility metadata lives. 

## How Has This Been Tested?
Wrote test cases 

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
NA