### PR TITLE
Add Resource Template support to basic-host

### DIFF
--- a/examples/basic-host/src/implementation.ts
+++ b/examples/basic-host/src/implementation.ts
@@ -60,11 +60,21 @@ export function hasAppHtml(toolCallInfo: ToolCallInfo): toolCallInfo is Required
 }
 
 
-export function callTool(
+/**
+ * Resolves URI template parameters like {param} with values from structuredContent
+ */
+function resolveUriParameters(uriTemplate: string, structuredContent: Record<string, unknown>): string {
+  return uriTemplate.replace(/\{(\w+)\}/g, (match, paramName) => {
+    const value = structuredContent[paramName];
+    return value !== undefined ? String(value) : match;
+  });
+}
+
+export async function callTool(
   serverInfo: ServerInfo,
   name: string,
   input: Record<string, unknown>,
-): ToolCallInfo {
+): Promise<ToolCallInfo> {
   log.info("Calling tool", name, "with input", input);
   const resultPromise = serverInfo.client.callTool({ name, arguments: input }) as Promise<CallToolResult>;
 
@@ -74,10 +84,17 @@ export function callTool(
   }
 
   const toolCallInfo: ToolCallInfo = { serverInfo, tool, input, resultPromise };
+  let result = await resultPromise;
 
   const uiResourceUri = getToolUiResourceUri(tool);
   if (uiResourceUri) {
-    toolCallInfo.appResourcePromise = getUiResource(serverInfo, uiResourceUri);
+    // Replace URL parameters with values from structuredContent
+    let resolvedUri = uiResourceUri;
+    if (result.structuredContent && typeof result.structuredContent === 'object') {
+      resolvedUri = resolveUriParameters(uiResourceUri, result.structuredContent);
+      log.info(`Resolved URI: ${uiResourceUri} -> ${resolvedUri}`);
+    }
+    toolCallInfo.appResourcePromise = getUiResource(serverInfo, resolvedUri);
   }
 
   return toolCallInfo;

--- a/examples/basic-host/src/index.tsx
+++ b/examples/basic-host/src/index.tsx
@@ -160,12 +160,12 @@ function CallToolPanel({ serversPromise, addToolCall, initialServer, initialTool
   };
 
   // Submit with optional override for server/tool (used by auto-call)
-  const handleSubmit = (overrideServer?: ServerInfo, overrideTool?: string) => {
+  const handleSubmit = async (overrideServer?: ServerInfo, overrideTool?: string) => {
     const server = overrideServer ?? selectedServer;
     const tool = overrideTool ?? selectedTool;
     if (!server) return;
 
-    const toolCallInfo = callTool(server, tool, JSON.parse(inputJson));
+    const toolCallInfo = await callTool(server, tool, JSON.parse(inputJson));
     addToolCall(toolCallInfo);
 
     // Update URL for easy refresh/sharing (without triggering navigation)
@@ -178,7 +178,7 @@ function CallToolPanel({ serversPromise, addToolCall, initialServer, initialTool
 
   return (
     <div className={styles.callToolPanel}>
-      <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }}>
+      <form onSubmit={async (e) => { e.preventDefault(); await handleSubmit(); }}>
         <label>
           Server
           <Suspense fallback={<select disabled><option>Loading...</option></select>}>


### PR DESCRIPTION
This PR updates the `basic-host` to support MCP Resource Templates. The changes are backward compatible: if a tool provides a static URI, it behaves as before. If it provides a URI template, the host will fill in the parameters before fetching the resource.

### Why this change?

The current implementation only supports static resources. Supporting Resource Templates allows for **Server-Side Rendering (SSR)**. This simplifies app development because the server can inject data directly into the HTML before it is sent to the host, reducing the need for complex JavaScript inside the app's sandbox.

### How to test

You can test this SSR flow using the following sample app:

1. **Server**: Use the [Pizza Carousel Sample App](https://github.com/rinormaloku/MCP-Nest-Samples/tree/main/pizzaz-mcp-apps-ext).
2. **Tool**: Call the `pizza-carousel` tool.
3. **Arguments**: `topping=vegetarian`.
4. **Expectation**: The host will detect the template, replace the parameter to form the URI `ui://widget/pizza-carousel/vegetarian`, and render the page showing only vegetarian options.

**References:**

* [Tool definition example](https://github.com/rinormaloku/MCP-Nest-Samples/blob/main/pizzaz-mcp-apps-ext/src/pizzaz.tool.ts#L52-L88)
* [Resource template implementation](https://github.com/rinormaloku/MCP-Nest-Samples/blob/main/pizzaz-mcp-apps-ext/src/pizzaz.resource.ts#L83-L124)
