### PR TITLE
feat(shadertoy): add streaming partial input, visibility optimization, host styling

### DIFF
--- a/examples/shadertoy-server/mcp-app.html
+++ b/examples/shadertoy-server/mcp-app.html
@@ -9,6 +9,7 @@
 <body>
   <main class="main">
     <canvas id="canvas"></canvas>
+    <pre id="code-preview"></pre>
     <button id="fullscreen-btn" class="fullscreen-btn" title="Toggle fullscreen">
       <svg class="expand-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/>

--- a/examples/shadertoy-server/src/mcp-app.css
+++ b/examples/shadertoy-server/src/mcp-app.css
@@ -11,11 +11,45 @@ html, body {
   width: 100%;
   height: 100%;
   min-height: 400px;
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+}
+
+.main.fullscreen {
+  border-radius: 0;
 }
 
 #canvas {
   width: 100%;
   height: 100%;
+  display: block;
+}
+
+#canvas.hidden {
+  display: none;
+}
+
+#code-preview {
+  display: none;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 16px;
+  box-sizing: border-box;
+  overflow: auto;
+  background: linear-gradient(
+    135deg,
+    var(--color-background-secondary) 0%,
+    var(--color-background-tertiary) 100%
+  );
+  color: var(--color-text-ghost);
+  font-family: var(--font-mono);
+  font-size: var(--font-text-xs-size);
+  line-height: var(--font-text-xs-line-height);
+  white-space: pre-wrap;
+}
+
+#code-preview.visible {
   display: block;
 }
 


### PR DESCRIPTION
## Summary

Enhances the shadertoy-server example with best practices for MCP Apps, and documents these patterns in the create-mcp-app skill.

## Shadertoy Server Improvements

- **Streaming partial input**: Shows code preview during LLM generation via `ontoolinputpartial` handler
- **Visibility optimization**: Uses `IntersectionObserver` to pause/play shader when scrolled in/out of viewport
- **Host styling integration**: Applies theme and CSS variables from host context
- **Visual polish**: Gradient background, ghost text color for code preview, border-radius (removed in fullscreen)

## Skill Documentation Updates

- **Streaming partial input** section: Explains healed JSON, use cases (code preview, progressive forms, live charts)
- **Visibility-based resource management**: Pattern for pausing expensive operations
- **Fullscreen mode**: API usage and CSS patterns
- **CSS variables**: Examples for using host style variables in stylesheets

## Testing

```bash
cd examples/shadertoy-server
npm run build && npm run dev
```

Connect via MCP Inspector or Claude Desktop to test streaming and visibility features.