### PR TITLE
Add paint-server example

### DIFF
--- a/examples/paint-server/main.ts
+++ b/examples/paint-server/main.ts
@@ -1,0 +1,82 @@
+/**
+ * Entry point for the paint MCP server.
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import cors from "cors";
+import type { Request, Response } from "express";
+import { createServer } from "./server.js";
+
+export interface ServerOptions {
+  port: number;
+  name?: string;
+}
+
+export async function startServer(
+  createServer: () => McpServer,
+  options: ServerOptions,
+): Promise<void> {
+  const { port, name = "MCP Server" } = options;
+
+  const app = createMcpExpressApp({ host: "0.0.0.0" });
+  app.use(cors());
+
+  app.all("/mcp", async (req: Request, res: Response) => {
+    const server = createServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    res.on("close", () => {
+      transport.close().catch(() => {});
+      server.close().catch(() => {});
+    });
+
+    try {
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      console.error("MCP error:", error);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: "2.0",
+          error: { code: -32603, message: "Internal server error" },
+          id: null,
+        });
+      }
+    }
+  });
+
+  const httpServer = app.listen(port, (err) => {
+    if (err) {
+      console.error("Failed to start server:", err);
+      process.exit(1);
+    }
+    console.log(`${name} listening on http://localhost:${port}/mcp`);
+  });
+
+  const shutdown = () => {
+    console.log("\nShutting down...");
+    httpServer.close(() => process.exit(0));
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+async function main() {
+  if (process.argv.includes("--stdio")) {
+    await createServer().connect(new StdioServerTransport());
+  } else {
+    const port = parseInt(process.env.PORT ?? "3108", 10);
+    await startServer(createServer, { port, name: "Paint MCP App Server" });
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/examples/paint-server/mcp-app.html
+++ b/examples/paint-server/mcp-app.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>Paint</title>
+  </head>
+  <body>
+    <main id="main">
+      <div id="toolbar">
+        <div id="colors"></div>
+        <button id="clear-btn" title="Clear canvas">Clear</button>
+      </div>
+      <canvas id="canvas"></canvas>
+    </main>
+    <script type="module" src="/src/mcp-app.ts"></script>
+  </body>
+</html>

--- a/examples/paint-server/package.json
+++ b/examples/paint-server/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@modelcontextprotocol/server-paint",
+  "version": "0.4.1",
+  "type": "module",
+  "description": "Minimalistic painting MCP App with model context image updates",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "directory": "examples/paint-server"
+  },
+  "license": "MIT",
+  "main": "dist/server.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --noEmit && cross-env INPUT=mcp-app.html vite build && tsc -p tsconfig.server.json && bun build server.ts --outdir dist --target node && bun build main.ts --outfile dist/index.js --target node --external \"./server.js\" --banner \"#!/usr/bin/env node\"",
+    "watch": "cross-env INPUT=mcp-app.html vite build --watch",
+    "serve": "bun --watch main.ts",
+    "start": "cross-env NODE_ENV=development npm run build && npm run serve",
+    "dev": "cross-env NODE_ENV=development concurrently 'npm run watch' 'npm run serve'"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/ext-apps": "^0.4.1",
+    "@modelcontextprotocol/sdk": "^1.24.0",
+    "cors": "^2.8.5",
+    "express": "^5.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.0.0",
+    "concurrently": "^9.2.1",
+    "cross-env": "^10.1.0",
+    "typescript": "^5.9.3",
+    "vite": "^6.0.0",
+    "vite-plugin-singlefile": "^2.3.0"
+  },
+  "types": "dist/server.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/server.d.ts",
+      "default": "./dist/server.js"
+    }
+  },
+  "bin": {
+    "mcp-server-paint": "dist/index.js"
+  }
+}

--- a/examples/paint-server/server.ts
+++ b/examples/paint-server/server.ts
@@ -1,0 +1,74 @@
+/**
+ * Paint MCP App Server
+ *
+ * Provides a simple drawing canvas tool. The widget sends the current
+ * drawing as an image via updateModelContext so the model can "see" it.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  registerAppTool,
+  registerAppResource,
+  RESOURCE_MIME_TYPE,
+} from "@modelcontextprotocol/ext-apps/server";
+import type {
+  CallToolResult,
+  ReadResourceResult,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST_DIR = __dirname; // mcp-app.html is in the same dir as the built server
+
+const resourceUri = "ui://draw/mcp-app.html";
+
+export function createServer(): McpServer {
+  const server = new McpServer({
+    name: "paint",
+    version: "1.0.0",
+  });
+
+  registerAppTool(
+    server,
+    "draw",
+    {
+      title: "Draw",
+      description:
+        "Opens a drawing canvas where the user can paint with different colors. " +
+        "The current drawing is automatically shared as model context.",
+      inputSchema: {},
+      _meta: { ui: { resourceUri } },
+    },
+    async (): Promise<CallToolResult> => {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "Drawing canvas opened. The user can now draw. Their drawing will be shared with you as model context (image). Ask the user what they drew, or wait for them to tell you.",
+          },
+        ],
+      };
+    },
+  );
+
+  registerAppResource(
+    server,
+    resourceUri,
+    resourceUri,
+    { mimeType: RESOURCE_MIME_TYPE },
+    async (): Promise<ReadResourceResult> => {
+      const html = await fs.readFile(
+        path.join(DIST_DIR, "mcp-app.html"),
+        "utf-8",
+      );
+      return {
+        contents: [{ uri: resourceUri, mimeType: RESOURCE_MIME_TYPE, text: html }],
+      };
+    },
+  );
+
+  return server;
+}

--- a/examples/paint-server/src/mcp-app.css
+++ b/examples/paint-server/src/mcp-app.css
@@ -1,0 +1,75 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+  font-family: system-ui, sans-serif;
+  background: var(--color-bg-primary, #fff);
+}
+
+#main {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+#toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border-bottom: 1px solid var(--color-border-primary, #ddd);
+  background: var(--color-bg-secondary, #f5f5f5);
+}
+
+#colors {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.color-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: border-color 0.1s;
+}
+
+.color-swatch:hover {
+  border-color: var(--color-text-secondary, #666);
+}
+
+.color-swatch.active {
+  border-color: var(--color-text-primary, #000);
+  box-shadow: 0 0 0 2px var(--color-bg-primary, #fff),
+    0 0 0 4px var(--color-text-primary, #000);
+}
+
+#clear-btn {
+  margin-left: auto;
+  padding: 4px 12px;
+  border: 1px solid var(--color-border-primary, #ccc);
+  border-radius: 4px;
+  background: var(--color-bg-primary, #fff);
+  color: var(--color-text-primary, #333);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+#clear-btn:hover {
+  background: var(--color-bg-tertiary, #eee);
+}
+
+#canvas {
+  flex: 1;
+  width: 100%;
+  cursor: crosshair;
+  touch-action: none;
+}

--- a/examples/paint-server/src/mcp-app.ts
+++ b/examples/paint-server/src/mcp-app.ts
@@ -1,0 +1,177 @@
+/**
+ * Paint MCP App Widget
+ *
+ * Simple freehand drawing canvas with color picker.
+ * Sends the current drawing as an image to the model via updateModelContext.
+ */
+
+import "./mcp-app.css";
+import { App } from "@modelcontextprotocol/ext-apps";
+
+const COLORS = [
+  "#000000", // black
+  "#ef4444", // red
+  "#f97316", // orange
+  "#eab308", // yellow
+  "#22c55e", // green
+  "#3b82f6", // blue
+  "#8b5cf6", // purple
+  "#ec4899", // pink
+  "#ffffff", // white (eraser on white bg)
+];
+
+const DEBOUNCE_MS = 1000;
+const MAX_EXPORT_DIM = 256; // max px on longest side (4000 token limit in model context)
+const LINE_WIDTH = 4;
+const PREFERRED_HEIGHT = 350;
+
+// State
+let currentColor = COLORS[0];
+let isDrawing = false;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Elements
+const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+const ctx = canvas.getContext("2d")!;
+const colorsContainer = document.getElementById("colors")!;
+const clearBtn = document.getElementById("clear-btn")!;
+
+// App instance
+const app = new App({ name: "Paint", version: "1.0.0" });
+
+// --- Color Picker ---
+
+function createColorSwatches(): void {
+  for (const color of COLORS) {
+    const swatch = document.createElement("div");
+    swatch.className = "color-swatch" + (color === currentColor ? " active" : "");
+    swatch.style.backgroundColor = color;
+    if (color === "#ffffff") {
+      swatch.style.border = "2px solid #ccc";
+    }
+    swatch.addEventListener("click", () => {
+      currentColor = color;
+      document.querySelectorAll(".color-swatch").forEach((s) => s.classList.remove("active"));
+      swatch.classList.add("active");
+    });
+    colorsContainer.appendChild(swatch);
+  }
+}
+
+// --- Canvas Setup ---
+
+function resizeCanvas(): void {
+  const rect = canvas.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  ctx.scale(dpr, dpr);
+  // Fill white background
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, rect.width, rect.height);
+}
+
+function getPointerPos(e: PointerEvent): { x: number; y: number } {
+  const rect = canvas.getBoundingClientRect();
+  return {
+    x: e.clientX - rect.left,
+    y: e.clientY - rect.top,
+  };
+}
+
+function startStroke(e: PointerEvent): void {
+  isDrawing = true;
+  canvas.setPointerCapture(e.pointerId);
+  const pos = getPointerPos(e);
+  ctx.beginPath();
+  ctx.moveTo(pos.x, pos.y);
+  ctx.strokeStyle = currentColor;
+  ctx.lineWidth = LINE_WIDTH;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+}
+
+function continueStroke(e: PointerEvent): void {
+  if (!isDrawing) return;
+  const pos = getPointerPos(e);
+  ctx.lineTo(pos.x, pos.y);
+  ctx.stroke();
+}
+
+function endStroke(): void {
+  if (!isDrawing) return;
+  isDrawing = false;
+  ctx.closePath();
+  scheduleContextUpdate();
+}
+
+function clearCanvas(): void {
+  const rect = canvas.getBoundingClientRect();
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, rect.width, rect.height);
+  scheduleContextUpdate();
+}
+
+// --- Model Context Update ---
+
+function scheduleContextUpdate(): void {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    sendCanvasToModel();
+  }, DEBOUNCE_MS);
+}
+
+function sendCanvasToModel(): void {
+  // Scale down preserving aspect ratio, max dimension = MAX_EXPORT_DIM
+  const scale = Math.min(MAX_EXPORT_DIM / canvas.width, MAX_EXPORT_DIM / canvas.height, 1);
+  const exportW = Math.round(canvas.width * scale);
+  const exportH = Math.round(canvas.height * scale);
+  const exportCanvas = document.createElement("canvas");
+  exportCanvas.width = exportW;
+  exportCanvas.height = exportH;
+  const exportCtx = exportCanvas.getContext("2d")!;
+  exportCtx.drawImage(canvas, 0, 0, exportW, exportH);
+
+  const dataUrl = exportCanvas.toDataURL("image/png");
+  const base64 = dataUrl.split(",")[1];
+
+  app.updateModelContext({
+    content: [
+      { type: "image", data: base64, mimeType: "image/png" },
+    ],
+  });
+
+  app.sendLog({
+    level: "info",
+    data: `updateModelContext: sent ${exportW}x${exportH} drawing (${base64.length} chars base64)`,
+    logger: "paint",
+  });
+}
+
+// --- Init ---
+
+function init(): void {
+  createColorSwatches();
+  resizeCanvas();
+
+  // Drawing events
+  canvas.addEventListener("pointerdown", startStroke);
+  canvas.addEventListener("pointermove", continueStroke);
+  canvas.addEventListener("pointerup", endStroke);
+  canvas.addEventListener("pointerleave", endStroke);
+  canvas.addEventListener("pointercancel", endStroke);
+
+  // Clear button
+  clearBtn.addEventListener("click", clearCanvas);
+
+  // Resize handling
+  window.addEventListener("resize", resizeCanvas);
+
+  // Connect to host
+  app.onerror = console.error;
+  app.connect().then(() => {
+    app.sendSizeChanged({ height: PREFERRED_HEIGHT });
+  });
+}
+
+init();

--- a/examples/paint-server/tsconfig.json
+++ b/examples/paint-server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "server.ts"]
+}

--- a/examples/paint-server/tsconfig.server.json
+++ b/examples/paint-server/tsconfig.server.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["server.ts"]
+}

--- a/examples/paint-server/vite.config.ts
+++ b/examples/paint-server/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+
+const INPUT = process.env.INPUT;
+if (!INPUT) {
+  throw new Error("INPUT environment variable is not set");
+}
+
+const isDevelopment = process.env.NODE_ENV === "development";
+
+export default defineConfig({
+  plugins: [viteSingleFile()],
+  build: {
+    sourcemap: isDevelopment ? "inline" : undefined,
+    cssMinify: !isDevelopment,
+    minify: !isDevelopment,
+
+    rollupOptions: {
+      input: INPUT,
+    },
+    outDir: "dist",
+    emptyOutDir: false,
+  },
+});


### PR DESCRIPTION
Simple MCP App example: minimalistic drawing canvas with color picker.

## What it does

- Opens a drawing canvas via the `draw` tool
- User picks colors and draws freehand
- Drawing is debounced (1s) and sent as a PNG image via `updateModelContext`
- Model can then describe what the user drew

## Implementation

- Based on `basic-server-vanillajs` template
- Vanilla JS, no React
- Canvas scales export to max 256px (longest side)
- Uses pointer events for mouse + touch support

## Testing

1. Add to Claude Desktop config:
```json
"paint": {
  "command": "node",
  "args": ["path/to/ext-apps/examples/paint-server/dist/index.js", "--stdio"]
}
```
2. Ask Claude to `draw`
3. Draw something on the canvas
4. Ask Claude "what did I draw?"
