### PR TITLE
fix(spec): align permissions type with SDK implementation

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -174,25 +174,25 @@ interface UIResourceMeta {
      *
      * Maps to Permission Policy `camera` feature
      */
-    camera?: boolean,
+    camera?: {},
     /**
      * Request microphone access
      *
      * Maps to Permission Policy `microphone` feature
      */
-    microphone?: boolean,
+    microphone?: {},
     /**
      * Request geolocation access
      *
      * Maps to Permission Policy `geolocation` feature
      */
-    geolocation?: boolean,
+    geolocation?: {},
     /**
      * Request clipboard write access
      *
      * Maps to Permission Policy `clipboard-write` feature
      */
-    clipboardWrite?: boolean,
+    clipboardWrite?: {},
   },
   /**
    * Dedicated origin for widget
@@ -239,10 +239,10 @@ The resource content is returned via `resources/read`:
           baseUriDomains?: string[]; // Allowed base URIs for the document (base-uri directive).
         };
         permissions?: {
-          camera?: boolean;           // Request camera access
-          microphone?: boolean;       // Request microphone access
-          geolocation?: boolean;      // Request geolocation access
-          clipboardWrite?: boolean;   // Request clipboard write access
+          camera?: {};           // Request camera access
+          microphone?: {};       // Request microphone access
+          geolocation?: {};      // Request geolocation access
+          clipboardWrite?: {};   // Request clipboard write access
         };
         domain?: string;
         prefersBorder?: boolean;
@@ -615,10 +615,10 @@ interface HostCapabilities {
   sandbox?: {
     /** Permissions granted by the host (camera, microphone, geolocation, clipboard-write). */
     permissions?: {
-      camera?: boolean;
-      microphone?: boolean;
-      geolocation?: boolean;
-      clipboardWrite?: boolean;
+      camera?: {};
+      microphone?: {};
+      geolocation?: {};
+      clipboardWrite?: {};
     };
     /** CSP domains approved by the host. */
     csp?: {
@@ -1179,10 +1179,10 @@ These messages are reserved for web-based hosts that implement the recommended d
       baseUriDomains?: string[],
     },
     permissions?: {      // Sandbox permissions from resource metadata
-      camera?: boolean,
-      microphone?: boolean,
-      geolocation?: boolean,
-      clipboardWrite?: boolean,
+      camera?: {},
+      microphone?: {},
+      geolocation?: {},
+      clipboardWrite?: {},
     }
   }
 }


### PR DESCRIPTION
## Problem

The spec document incorrectly defined permission fields (`camera`, `microphone`, `geolocation`, `clipboardWrite`) as `boolean` types, but the SDK implementation uses empty object types (`{}`).

This caused validation errors for MCP servers (like Hex) that followed the spec and sent boolean values like `clipboardWrite: true`, when the Zod schema expects `clipboardWrite: {}`.

**Error message:**
```json
{
  "code": "invalid_type",
  "expected": "object",
  "received": "boolean",
  "path": ["permissions", "clipboardWrite"],
  "message": "Expected object, received boolean"
}
```

## Root Cause

| Layer | Value | Status |
|-------|-------|--------|
| `spec.types.ts` (TypeScript source) | `clipboardWrite?: {}` | ✅ Source of truth |
| `schema.ts` (generated Zod) | `z.object({}).optional()` | ✅ Correct |
| `schema.json` (generated JSON Schema) | `"type": "object"` | ✅ Correct |
| **`apps.mdx`** (human spec doc) | `clipboardWrite?: boolean` | ❌ Out of sync |

## Fix

Updated all 4 occurrences of permission types in `apps.mdx` from `boolean` to `{}` to match the TypeScript source of truth.

## Design Rationale

The empty object design was intentional to allow future extensibility (e.g., adding options like `{ required: true }` or `{ fallback: "deny" }`). The spec doc was never updated to reflect this decision.