### PR TITLE
Add `.claude-plugin/marketplace.json` for plugin distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "mcp-apps",
+  "description": "Plugins for MCP Apps development",
+  "owner": {
+    "name": "MCP Apps"
+  },
+  "plugins": [
+    {
+      "name": "mcp-apps",
+      "source": "./plugins/mcp-apps",
+      "description": "Skills for creating MCP Apps with the MCP Apps SDK"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -44,14 +44,13 @@ We have [contributed a tentative implementation](https://github.com/MCP-UI-Org/m
 npm install -S @modelcontextprotocol/ext-apps
 ```
 
-Or edit your `package.json` manually:
+### Claude Code Plugin
 
-```json
-{
-  "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^0.0.1"
-  }
-}
+A [Claude Code plugin](https://github.com/modelcontextprotocol/ext-apps/tree/main/plugins/mcp-apps) is available to help create MCP Apps. To install, run these commands inside Claude Code:
+
+```
+/plugin marketplace add modelcontextprotocol/ext-apps
+/plugin install mcp-apps@modelcontextprotocol-ext-apps
 ```
 
 ## Examples

--- a/plugins/mcp-apps/.claude-plugin/plugin.json
+++ b/plugins/mcp-apps/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "MCP Apps"
   },
-  "repository": "https://github.com/anthropics/mcp-ext-apps",
+  "repository": "https://github.com/modelcontextprotocol/ext-apps",
   "license": "MIT",
   "keywords": ["mcp", "mcp-apps", "model-context-protocol", "ui", "interactive"]
 }

--- a/plugins/mcp-apps/README.md
+++ b/plugins/mcp-apps/README.md
@@ -6,9 +6,10 @@ A Claude Code plugin that provides the "Create MCP App" skill for building MCP A
 
 Install via Claude Code:
 
-1. Run `/plugin` in Claude Code
-2. Navigate to the Discover tab
-3. Install "mcp-apps"
+```
+/plugin marketplace add modelcontextprotocol/ext-apps
+/plugin install mcp-apps@modelcontextprotocol-ext-apps
+```
 
 ## Usage
 


### PR DESCRIPTION
This enables users to install the `mcp-apps` plugin via:

    /plugin marketplace add modelcontextprotocol/ext-apps
    /plugin install mcp-apps@modelcontextprotocol-ext-apps
