### PR TITLE
fix(say-server): clean up README

### DIFF
--- a/examples/say-server/README.md
+++ b/examples/say-server/README.md
@@ -48,7 +48,7 @@ Run directly from GitHub using the official `uv` Docker image:
 ```bash
 docker run --rm -it \
   -p 3109:3109 \
-  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -v ~/.cache/huggingface-docker-say-server:/root/.cache/huggingface \
   ghcr.io/astral-sh/uv:debian \
   uv run https://raw.githubusercontent.com/modelcontextprotocol/ext-apps/main/examples/say-server/server.py
 ```


### PR DESCRIPTION
## Summary

Fixes issues with the say-server README introduced in #304:

- **Add screenshot** - Was missing despite screenshot.png being in the directory
- **Remove GPU prerequisite** - Wasn't needed or requested
- **Use GitHub raw URLs** - Instead of confusing local file paths
- **Simplify Docker section** - Remove unnecessary HF_HOME env var and GPU support mention
- **Fix Claude Desktop config** - Use remote URL so users don't need to clone the repo