### PR TITLE
docs(spec): clarify ui.domain is host-dependent

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -198,12 +198,20 @@ interface UIResourceMeta {
    * Dedicated origin for widget
    *
    * Optional domain for the widget's sandbox origin. Useful when widgets need
-   * dedicated origins for API key allowlists or cross-origin isolation.
+   * stable, dedicated origins for OAuth callbacks, CORS policies, or API key allowlists.
    *
-   * If omitted, Host uses default sandbox origin.
+   * **Host-dependent:** The format and validation rules for this field are
+   * determined by each host. Servers MUST consult host-specific documentation
+   * for the expected domain format. Common patterns include:
+   * - Hash-based subdomains (e.g., `{hash}.claudemcpcontent.com`)
+   * - URL-derived subdomains (e.g., `www-example-com.oaiusercontent.com`)
+   *
+   * If omitted, Host uses default sandbox origin (typically per-conversation).
    *
    * @example
-   * "https://weather-widget.example.com"
+   * "a904794854a047f6.claudemcpcontent.com"
+   * @example
+   * "www-example-com.oaiusercontent.com"
    */
   domain?: string,
   /**


### PR DESCRIPTION
## Summary

Clarifies that `ui.domain` format and validation rules are host-dependent, addressing the gap between the spec's previous implied flexibility and real-world constraints.

**Fixes:** Addresses feedback from https://github.com/anthropics/apps/pull/19201#issuecomment-3769736628

## Changes

Updates the `ui.domain` field documentation to:

1. **Clarify host-dependency**: The format and validation rules for `ui.domain` are determined by each host
2. **Add common patterns**: 
   - Hash-based subdomains (e.g., `{hash}.claudemcpcontent.com`)
   - URL-derived subdomains (e.g., `www-example-com.oaiusercontent.com`)
3. **Update examples**: Replace unrealistic `https://weather-widget.example.com` with actual host-controlled domain patterns
4. **Improve description**: Clarify purpose (OAuth callbacks, CORS policies, API key allowlists) and behavior when omitted

## Rationale

The previous spec example `https://weather-widget.example.com` implied servers could specify arbitrary domains. In practice, hosts cannot serve UI from arbitrary domains - they must control the domain for security. Each host determines its own domain format and validation rules.

This change sets realistic expectations for server developers while keeping the spec generic enough to accommodate different host implementations.