### PR TITLE
fix(qr-server): remove deprecated FastMCP constructor args

### DIFF
--- a/examples/qr-server/server.py
+++ b/examples/qr-server/server.py
@@ -27,7 +27,7 @@ WIDGET_URI = "ui://qr-server/widget.html"
 HOST = os.environ.get("HOST", "0.0.0.0")  # 0.0.0.0 for Docker compatibility
 PORT = int(os.environ.get("PORT", "3108"))
 
-mcp = FastMCP("QR Code Server", port=PORT, stateless_http=True)
+mcp = FastMCP("QR Code Server")
 
 
 @mcp.tool(meta={


### PR DESCRIPTION
The Python SDK (modelcontextprotocol/python-sdk#1898) moved transport-specific parameters (`port`, `stateless_http`) from `FastMCP` constructor to `run()`. This broke the qr-server when run via stdio.

The port is already passed directly to `uvicorn.run()` for HTTP mode, so these constructor args were redundant.