### PR TITLE
fix: followup app -> view terminology

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -718,7 +718,7 @@ When using flexible dimensions (no fixed `height` or `width`), hosts MUST listen
 ```typescript
 // Host listens for size changes from the View
 bridge.onsizechange = ({ width, height }) => {
-  // Update iframe to match app's content size
+  // Update iframe to match View's content size
   if (width != null) {
     iframe.style.width = `${width}px`;
   }


### PR DESCRIPTION
Some parts of the spec use `app` to refer to a `view` (#71). This PR weeds out these instances by context (following up on #325).

No breaking changes - just prose.