### PR TITLE
Add Codex and Goose to documentation

### DIFF
--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -44,6 +44,7 @@ Then copy the skills from `plugins/mcp-apps/skills/` to your agent's skills dire
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/skills)
 - [VS Code](https://code.visualstudio.com/docs/copilot/customization/agent-skills) / [GitHub Copilot](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
+- [Codex](https://developers.openai.com/codex/skills/)
 - [Gemini CLI](https://geminicli.com/docs/cli/skills/)
 - [Cline](https://docs.cline.bot/features/skills#skills)
 - [Goose](https://block.github.io/goose/docs/guides/context-engineering/using-skills/)

--- a/docs/testing-mcp-apps.md
+++ b/docs/testing-mcp-apps.md
@@ -61,7 +61,8 @@ To test your App in a real conversational environment, install your MCP server i
 - Claude\.ai
   - [Remote MCP servers (over HTTP)](https://claude.ai/docs/connectors/custom/remote-mcp)
   - [Local MCP servers (over stdio)](https://claude.ai/docs/connectors/custom/desktop-extensions)
-- [VS Code Copilot](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
+- [VS Code (Insiders)](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
+- [Goose](https://block.github.io/goose/docs/getting-started/using-extensions/)
 
 Once your server is configured, ask the agent to perform a task related to your App-enhanced tool. For example, if you have a weather App, ask the agent "Show me the current weather."
 


### PR DESCRIPTION
Add Codex to the list of agents supporting skills in `agent-skills.md`. Add Goose to the list of supported clients in `testing-mcp-apps.md` and rename "VS Code Copilot" to "VS Code (Insiders)" for accuracy.
