### PR TITLE
fix(qr-server): use stable mcp SDK from PyPI

### DIFF
--- a/examples/qr-server/server.py
+++ b/examples/qr-server/server.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "mcp @ git+https://github.com/modelcontextprotocol/python-sdk@main",
+#     "mcp>=1.26.0",
 #     "qrcode[pil]>=8.0",
 #     "uvicorn>=0.34.0",
 #     "starlette>=0.46.0",
@@ -19,7 +19,6 @@ import base64
 import qrcode
 import uvicorn
 from mcp.server.fastmcp import FastMCP
-from mcp.server.transport_security import TransportSecuritySettings
 from mcp import types
 from starlette.middleware.cors import CORSMiddleware
 
@@ -162,11 +161,7 @@ if __name__ == "__main__":
         mcp.run(transport="stdio")
     else:
         # HTTP mode for basic-host (default) - with CORS
-        # Allow Docker bridge IP for container-to-host communication
-        security = TransportSecuritySettings(
-            allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*", "172.17.0.1:*"]
-        )
-        app = mcp.streamable_http_app(stateless_http=True, transport_security=security)
+        app = mcp.streamable_http_app()
         app.add_middleware(
             CORSMiddleware,
             allow_origins=["*"],


### PR DESCRIPTION
Fix qr-server startup failures by using mcp>=1.26.0 from PyPI and removing TransportSecuritySettings that blocked browser connections.