### PR TITLE
fix(qr-server): use stable mcp SDK from PyPI

### DIFF
--- a/examples/qr-server/server.py
+++ b/examples/qr-server/server.py
@@ -26,7 +26,7 @@ VIEW_URI = "ui://qr-server/view.html"
 HOST = os.environ.get("HOST", "0.0.0.0")  # 0.0.0.0 for Docker compatibility
 PORT = int(os.environ.get("PORT", "3001"))
 
-mcp = FastMCP("QR Code Server")
+mcp = FastMCP("QR Code Server", stateless_http=True)
 
 # Embedded View HTML for self-contained usage (uv run <url> or unbundled)
 EMBEDDED_VIEW_HTML = """<!DOCTYPE html>


### PR DESCRIPTION
Fix qr-server by using mcp>=1.26.0 from PyPI, adding stateless_http=True, and removing TransportSecuritySettings that blocked browser connections.