### PR TITLE
fix(say-server): pin to released mcp version

### DIFF
--- a/examples/say-server/server.py
+++ b/examples/say-server/server.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "mcp @ git+https://github.com/modelcontextprotocol/python-sdk@main",
+#     "mcp>=1.26.0",
 #     "uvicorn>=0.34.0",
 #     "starlette>=0.46.0",
 #     "pocket-tts>=1.0.1",


### PR DESCRIPTION
## Summary
- Fix `say-server` Python example that was failing to start
- Pin to `mcp>=1.26.0` instead of `@main` branch

The `main` branch of the MCP Python SDK has removed `FastMCP` from `mcp.server.fastmcp` (likely moving it to the standalone [`fastmcp` package](https://pypi.org/project/fastmcp/)), causing import errors. The latest PyPI release (1.26.0) still includes `FastMCP`.

## Test plan
- [x] Verified `uv run examples/say-server/server.py --stdio` starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)