### PR TITLE
Fix: registerAppResource does not return registered resource, but void

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -45,6 +45,7 @@ import type {
   ResourceMetadata,
   ToolCallback,
   ReadResourceCallback,
+  RegisteredResource,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type {
   AnySchema,
@@ -305,8 +306,8 @@ export function registerAppResource(
   uri: string,
   config: McpUiAppResourceConfig,
   readCallback: ReadResourceCallback,
-): void {
-  server.registerResource(
+): RegisteredResource {
+  return server.registerResource(
     name,
     uri,
     {


### PR DESCRIPTION
`registerAppResource` does not return registered resource, but void. 

Integrators could not save the registered resource definition.

## Motivation and Context
Fix of `registerAppResource` return value.

## How Has This Been Tested?
Simple return value change

## Breaking Changes
Fix

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
