### PR TITLE
docs: add root npm install step for basic-host setup

### DIFF
--- a/docs/testing-mcp-apps.md
+++ b/docs/testing-mcp-apps.md
@@ -24,7 +24,6 @@ The [`basic-host`](https://github.com/modelcontextprotocol/ext-apps/tree/main/ex
    cd ext-apps
    npm install
    cd examples/basic-host
-   npm install
    ```
 
 2. Start basic-host, pointing it to your MCP server:


### PR DESCRIPTION
Add missing `npm install` step in the root directory before installing basic-host dependencies.

Without running `npm install` at the root first, the installation in `examples/basic-host` fails due to missing workspace dependencies.