### PR TITLE
fix(qr-server): pass host/port to FastMCP for Docker compatibility

### DIFF
--- a/examples/qr-server/server.py
+++ b/examples/qr-server/server.py
@@ -26,7 +26,7 @@ VIEW_URI = "ui://qr-server/view.html"
 HOST = os.environ.get("HOST", "0.0.0.0")  # 0.0.0.0 for Docker compatibility
 PORT = int(os.environ.get("PORT", "3001"))
 
-mcp = FastMCP("QR Code Server", stateless_http=True)
+mcp = FastMCP("QR Code Server", stateless_http=True, host=HOST, port=PORT)
 
 # Embedded View HTML for self-contained usage (uv run <url> or unbundled)
 EMBEDDED_VIEW_HTML = """<!DOCTYPE html>


### PR DESCRIPTION
## Problem

When using the qr-server in a Docker environment, requests fail with 421 Invalid Host header errors.

## Root Cause

MCP SDK 1.26+ introduced automatic DNS rebinding protection. When FastMCP is created with the default host=127.0.0.1, it automatically enables this protection which only allows requests from localhost, 127.0.0.1, and ::1.

In Docker deployments, the backend container sends requests with Host: host.docker.internal, which gets rejected.

## Solution

Pass host=HOST and port=PORT to the FastMCP constructor. Since HOST defaults to 0.0.0.0 (for Docker compatibility), this prevents the auto-enabling of DNS rebinding protection, allowing requests from any host.

## Testing

- Tested with Docker Compose deployment
- Confirmed qr-server now accepts requests from host.docker.internal
- Verified basic-host (http://localhost:8080/) still works correctly
