### PR TITLE
Fix `extractRegion()` matching region names that are substrings of others

### DIFF
--- a/scripts/sync-snippets.ts
+++ b/scripts/sync-snippets.ts
@@ -254,8 +254,9 @@ function extractRegion(
     );
   }
 
-  const regionStart = `//#region ${regionName}`;
-  const regionEnd = `//#endregion ${regionName}`;
+  const lineEnding = exampleContent.includes("\r\n") ? "\r\n" : "\n";
+  const regionStart = `//#region ${regionName}${lineEnding}`;
+  const regionEnd = `//#endregion ${regionName}${lineEnding}`;
 
   const startIndex = exampleContent.indexOf(regionStart);
   if (startIndex === -1) {


### PR DESCRIPTION
The `extractRegion()` function in `sync-snippets.ts` used `indexOf()` to find region markers like `//#region persistData`. This caused incorrect matching when one region name was a prefix of another—searching for `persistData` would match `//#region persistDataServer` first if it appeared earlier in the file.

The fix detects the file's line ending style and appends it to region markers, ensuring exact matches:
- `//#region persistData\n` no longer matches `//#region persistDataServer\n`

This corrects `docs/patterns.md` where the `persistData` code fence was incorrectly showing server-side code instead of client-side localStorage helpers.
