### PR TITLE
Configure Alpic deployment of debug example server

### DIFF
--- a/examples/debug-server/alpic.json
+++ b/examples/debug-server/alpic.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://assets.alpic.ai/alpic.json",
+  "installCommand": "npm install",
+  "startCommand": "node dist/index.js --stdio"
+}


### PR DESCRIPTION
Hello,

Alpic would be glad to host all example ext-apps MCP servers and setup automatic syncing with this repository.
Each push to this repository would deploy the last up-to-date version of the example apps.

In order to make it happen, two things would be needed:

1. An admin of this repository needs to connect Alpic to this organization
-> https://docs.alpic.ai/quickstart

2. For each example, an `alpic.json` containing the specific install/build/run commands needs to be created. In this PR, I've created one for the debug-server example.

The debug-server is currently hosted here, if you want to try it : `https://ext-apps-debug.alpic.live/`

If you're interested, I will take care of deploying each example and testing it's working as expected,

Kindly,

Valentin