### PR TITLE
Separate static and dynamic data in `system-monitor-server` tools

### DIFF
--- a/examples/system-monitor-server/README.md
+++ b/examples/system-monitor-server/README.md
@@ -79,18 +79,24 @@ To test local modifications, use this configuration (replace `~/code/ext-apps` w
 
 ### Server (`server.ts`)
 
-Exposes a single `get-system-stats` tool that returns:
+Exposes two tools demonstrating a polling pattern:
 
-- Raw per-core CPU timing data (idle/total counters)
-- Memory usage (used/total/percentage)
-- System info (hostname, platform, uptime)
+1. **`get-system-info`** (Model-visible) — Returns static system configuration:
+   - Hostname, platform, architecture
+   - CPU model and core count
+   - Total memory
 
-The tool is linked to a UI resource via `_meta.ui.resourceUri`.
+2. **`poll-system-stats`** (App-only, `visibility: ["app"]`) — Returns dynamic metrics:
+   - Per-core CPU timing data (idle/total counters)
+   - Memory usage (used/free/percentage)
+   - Uptime
+
+The Model-visible tool is linked to a UI resource via `_meta.ui.resourceUri`.
 
 ### App (`src/mcp-app.ts`)
 
+- Receives static system info via `ontoolresult` when the host sends the `get-system-info` result
+- Polls `poll-system-stats` every 2 seconds for dynamic metrics
 - Uses Chart.js for the stacked area chart visualization
-- Polls the server tool every 2 seconds
 - Computes CPU usage percentages client-side from timing deltas
 - Maintains a 30-point history (1 minute at 2s intervals)
-- Updates all UI elements on each poll


### PR DESCRIPTION
The two-tool architecture previously had both tools returning identical `SystemStats` data. This refactors them to properly separate concerns:

- `get-system-info` (Model-visible): Returns static system configuration (hostname, platform, CPU model/count, total memory) sent once via `ontoolresult`

- `poll-system-stats` (App-only): Returns dynamic metrics (per-core CPU timing, memory usage, uptime) polled every 2 seconds

Moves `formatBytes()` and `formatUptime()` utilities to the client since the server now returns raw values for client-side formatting.
