### PR TITLE
docs: fix basic-host setup instructions in quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -449,7 +449,6 @@ MCP server listening on http://localhost:3001/mcp
 git clone https://github.com/modelcontextprotocol/ext-apps.git
 cd ext-apps
 npm install
-npm run build
 cd examples/basic-host
 npm start
 ```


### PR DESCRIPTION
## Summary
- Add missing `npm install` and `npm run build` steps at the ext-apps root before running the basic-host example
- Without these steps, basic-host fails because it imports from `../../../dist/src/` which doesn't exist

## Problem
Following the current quickstart instructions:
```bash
git clone https://github.com/modelcontextprotocol/ext-apps.git
cd ext-apps/examples/basic-host
npm install
npm start
```

Results in build failures because:
1. The basic-host imports from `../../../dist/src/`
2. The dist directory doesn't exist until the root package is built
3. Building requires dev dependencies (like `ts-to-zod`) that aren't installed when only running `npm install` in the example directory

## Solution
Updated instructions to include root-level setup:
```bash
git clone https://github.com/modelcontextprotocol/ext-apps.git
cd ext-apps
npm install
npm run build
cd examples/basic-host
npm start
```

## Test Plan
- [x] Follow the updated quickstart instructions from scratch
- [x] Verify basic-host starts successfully at http://localhost:8080
- [x] Verify the get-time tool works correctly