### PR TITLE
Update basic-host imports to use package exports

### DIFF
--- a/examples/basic-host/src/sandbox.ts
+++ b/examples/basic-host/src/sandbox.ts
@@ -1,5 +1,5 @@
-import type { McpUiSandboxProxyReadyNotification, McpUiSandboxResourceReadyNotification } from "../../../dist/src/types";
-import { buildAllowAttribute } from "../../../dist/src/app-bridge";
+import type { McpUiSandboxProxyReadyNotification, McpUiSandboxResourceReadyNotification } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { buildAllowAttribute } from "@modelcontextprotocol/ext-apps/app-bridge";
 
 const ALLOWED_REFERRER_PATTERN = /^http:\/\/(localhost|127\.0\.0\.1)(:|\/|$)/;
 


### PR DESCRIPTION
Change `sandbox.ts` imports from relative paths into `dist/` to use the proper `@modelcontextprotocol/ext-apps/app-bridge` package entry point. This aligns the example with how external consumers would import from the package.
