### PR TITLE
docs(skill): add CSP location and CORS pitfalls to common mistakes

### DIFF
--- a/plugins/mcp-apps/skills/create-mcp-app/SKILL.md
+++ b/plugins/mcp-apps/skills/create-mcp-app/SKILL.md
@@ -314,10 +314,6 @@ See `examples/shadertoy-server/` for complete implementation.
 8. **No streaming for large inputs** - Use `ontoolinputpartial` to show progress during generation
 9. **CSP `_meta` in wrong location** - Put `_meta.ui.csp` in the `contents` array (readCallback), NOT in the `registerResource` config. Only the contents location is read by hosts:
    ```typescript
-   // WRONG - config param
-   registerAppResource(server, "View", "ui://app", { _meta: { ui: { csp: {...} } } }, callback);
-
-   // CORRECT - in contents returned by callback
    async () => ({
      contents: [{
        uri, mimeType, text: html,


### PR DESCRIPTION
Add three new items to the 'Common Mistakes to Avoid' section in the create-mcp-app skill:

- **#9 CSP `_meta` in wrong location** - Must be in `contents` array (readCallback), NOT in registerResource config
- **#10 Localhost in CSP blocked** - CSP validation blocks localhost/private IPs; use tunnels for local dev
- **#11 CORS vs CSP confusion** - Explains the difference and how to compute stable `ui.domain` for CORS allowlists