### PR TITLE
Replace "external" with "network" in CSP documentation

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -201,7 +201,7 @@ See the [Display Modes](https://github.com/modelcontextprotocol/ext-apps/blob/ma
 
 All Views run in sandboxed iframes with no access to the Host's DOM, cookies, or storage. Communication happens only through [`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage), making it auditable.
 
-Servers declare which external domains their UI needs via [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) metadata. Hosts enforce these declarations — if no domains are declared, no external connections are allowed. This "restrictive by default" approach prevents data exfiltration to undeclared servers.
+Servers declare which network domains their UI needs via [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) metadata. Hosts enforce these declarations — if no domains are declared, no external connections are allowed. This "restrictive by default" approach prevents data exfiltration to undeclared servers.
 
 See the [Security Implications](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx#security-implications) section of the specification for the threat model and mitigations.
 

--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -165,14 +165,14 @@
               "type": "object",
               "properties": {
                 "connectDomains": {
-                  "description": "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted → no external connections (secure default)",
+                  "description": "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted → no network connections (secure default)",
                   "type": "array",
                   "items": {
                     "type": "string"
                   }
                 },
                 "resourceDomains": {
-                  "description": "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted → no external resources (secure default)",
+                  "description": "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted → no network resources (secure default)",
                   "type": "array",
                   "items": {
                     "type": "string"
@@ -2511,14 +2511,14 @@
                   "type": "object",
                   "properties": {
                     "connectDomains": {
-                      "description": "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted → no external connections (secure default)",
+                      "description": "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted → no network connections (secure default)",
                       "type": "array",
                       "items": {
                         "type": "string"
                       }
                     },
                     "resourceDomains": {
-                      "description": "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted → no external resources (secure default)",
+                      "description": "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted → no network resources (secure default)",
                       "type": "array",
                       "items": {
                         "type": "string"
@@ -3874,14 +3874,14 @@
       "type": "object",
       "properties": {
         "connectDomains": {
-          "description": "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted → no external connections (secure default)",
+          "description": "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted → no network connections (secure default)",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "resourceDomains": {
-          "description": "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted → no external resources (secure default)",
+          "description": "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted → no network resources (secure default)",
           "type": "array",
           "items": {
             "type": "string"
@@ -3913,14 +3913,14 @@
           "type": "object",
           "properties": {
             "connectDomains": {
-              "description": "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted → no external connections (secure default)",
+              "description": "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted → no network connections (secure default)",
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
             "resourceDomains": {
-              "description": "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted → no external resources (secure default)",
+              "description": "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted → no network resources (secure default)",
               "type": "array",
               "items": {
                 "type": "string"
@@ -4082,14 +4082,14 @@
               "type": "object",
               "properties": {
                 "connectDomains": {
-                  "description": "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted → no external connections (secure default)",
+                  "description": "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted → no network connections (secure default)",
                   "type": "array",
                   "items": {
                     "type": "string"
                   }
                 },
                 "resourceDomains": {
-                  "description": "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted → no external resources (secure default)",
+                  "description": "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted → no network resources (secure default)",
                   "type": "array",
                   "items": {
                     "type": "string"

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -188,8 +188,7 @@ export const McpUiSandboxProxyReadyNotificationSchema = z.object({
 /**
  * @description Content Security Policy configuration for UI resources.
  *
- * Servers declare which external origins their UI needs to access.
- * Hosts use this to enforce appropriate CSP headers.
+ * Servers declare which origins their UI requires. Hosts use this to enforce appropriate CSP headers.
  *
  * > [!IMPORTANT]
  * > MCP App HTML runs in a sandboxed iframe with no same-origin server.
@@ -201,7 +200,7 @@ export const McpUiResourceCspSchema = z.object({
    * @description Origins for network requests (fetch/XHR/WebSocket).
    *
    * - Maps to CSP `connect-src` directive
-   * - Empty or omitted → no external connections (secure default)
+   * - Empty or omitted → no network connections (secure default)
    *
    * @example
    * ```ts
@@ -212,14 +211,14 @@ export const McpUiResourceCspSchema = z.object({
     .array(z.string())
     .optional()
     .describe(
-      "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted \u2192 no external connections (secure default)",
+      "Origins for network requests (fetch/XHR/WebSocket).\n\n- Maps to CSP `connect-src` directive\n- Empty or omitted \u2192 no network connections (secure default)",
     ),
   /**
    * @description Origins for static resources (images, scripts, stylesheets, fonts, media).
    *
    * - Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives
    * - Wildcard subdomains supported: `https://*.example.com`
-   * - Empty or omitted → no external resources (secure default)
+   * - Empty or omitted → no network resources (secure default)
    *
    * @example
    * ```ts
@@ -230,7 +229,7 @@ export const McpUiResourceCspSchema = z.object({
     .array(z.string())
     .optional()
     .describe(
-      "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted \u2192 no external resources (secure default)",
+      "Origins for static resources (images, scripts, stylesheets, fonts, media).\n\n- Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives\n- Wildcard subdomains supported: `https://*.example.com`\n- Empty or omitted \u2192 no network resources (secure default)",
     ),
   /**
    * @description Origins for nested iframes.

--- a/src/server/index.examples.ts
+++ b/src/server/index.examples.ts
@@ -164,7 +164,7 @@ function registerAppResource_basicUsage(server: McpServer) {
 }
 
 /**
- * Example: registerAppResource with CSP configuration for external domains.
+ * Example: registerAppResource with CSP configuration for network access.
  */
 function registerAppResource_withCsp(
   server: McpServer,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -270,7 +270,7 @@ export function registerAppTool<
  * );
  * ```
  *
- * @example With CSP configuration for external domains
+ * @example With CSP configuration for network access
  * ```ts source="./index.examples.ts#registerAppResource_withCsp"
  * registerAppResource(
  *   server,

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -539,8 +539,7 @@ export interface McpUiInitializedNotification {
 /**
  * @description Content Security Policy configuration for UI resources.
  *
- * Servers declare which external origins their UI needs to access.
- * Hosts use this to enforce appropriate CSP headers.
+ * Servers declare which origins their UI requires. Hosts use this to enforce appropriate CSP headers.
  *
  * > [!IMPORTANT]
  * > MCP App HTML runs in a sandboxed iframe with no same-origin server.
@@ -552,7 +551,7 @@ export interface McpUiResourceCsp {
    * @description Origins for network requests (fetch/XHR/WebSocket).
    *
    * - Maps to CSP `connect-src` directive
-   * - Empty or omitted → no external connections (secure default)
+   * - Empty or omitted → no network connections (secure default)
    *
    * @example
    * ```ts
@@ -565,7 +564,7 @@ export interface McpUiResourceCsp {
    *
    * - Maps to CSP `img-src`, `script-src`, `style-src`, `font-src`, `media-src` directives
    * - Wildcard subdomains supported: `https://*.example.com`
-   * - Empty or omitted → no external resources (secure default)
+   * - Empty or omitted → no network resources (secure default)
    *
    * @example
    * ```ts


### PR DESCRIPTION
The term "external" is misleading for MCP Apps because developers typically interpret it as "third-party." However, MCP App HTML runs in a sandboxed iframe with no same-origin server, so *all* origins must be declared—including where your own bundled JS/CSS is served from. Using "network" instead avoids this confusion and aligns with the detailed explanations in `patterns.md` and `spec.types.ts`.
