### PR TITLE
Add cross-host portability guide for MCP Apps

### DIFF
--- a/docs/portability.md
+++ b/docs/portability.md
@@ -1,0 +1,75 @@
+# Cross-Host Portability
+
+This guide covers issues that arise when running the same MCP App across multiple
+hosts (Claude, ChatGPT, custom hosts). For migrating from OpenAI Apps SDK, see
+the [Migration Guide](./migrate_from_openai_apps.md).
+
+## All Endpoints Need resources/*
+
+If your server exposes multiple MCP endpoints (authenticated routes, magic links,
+proxies), **each one** must handle `resources/list` and `resources/read`—not
+just the primary endpoint.
+
+Claude fetches widget HTML via `resources/read`. An endpoint that handles
+`initialize`, `tools/list`, and `tools/call` but returns 404 for `resources/*`
+will cause:
+
+```
+MCP error 32600: Session terminated
+```
+
+ChatGPT doesn't hit this because it uses `openai/outputTemplate` URLs directly.
+
+## Dual-Format Metadata
+
+To support both Claude and ChatGPT without separate codepaths, include both
+metadata formats:
+
+```json
+{
+  "name": "get_chart",
+  "_meta": {
+    "ui": {
+      "resourceUri": "ui://widget/chart.html",
+      "csp": { "connectDomains": ["https://api.example.com"] }
+    }
+  },
+  "openai/outputTemplate": "https://example.com/widgets/chart.html"
+}
+```
+
+ChatGPT ignores `_meta.ui`; Claude ignores `openai/*`. Both get what they need.
+
+Note: MCP Apps CSP is an object; OpenAI CSP is a string.
+
+## Throttle Size Notifications
+
+Widgets sending `ui/notifications/size-changed` on every resize flood the console.
+Debounce:
+
+```js
+let timeout;
+new ResizeObserver(() => {
+  clearTimeout(timeout);
+  timeout = setTimeout(() => {
+    app.notifySizeChanged({ height: document.body.scrollHeight });
+  }, 100);
+}).observe(document.body);
+```
+
+## Debugging
+
+| Symptom | Cause |
+|---------|-------|
+| Tools work, widgets blank | Endpoint missing `resources/read` |
+| "MCP error 32600: Session terminated" | `resources/*` returned error |
+| Works in ChatGPT, blank in Claude | Only `openai/*` metadata, no `_meta.ui` |
+| Console spam with "size-changed" | Resize notifications not debounced |
+
+## Related Resources
+
+- [migrate_from_openai_apps.md](https://github.com/modelcontextprotocol/ext-apps/blob/main/docs/migrate_from_openai_apps.md) — OpenAI to MCP Apps migration
+- [migrate-oai-app skill](https://github.com/modelcontextprotocol/ext-apps/tree/main/plugins/mcp-apps/skills/migrate-oai-app) — Agent-assisted migration
+- [patterns.md](https://github.com/modelcontextprotocol/ext-apps/blob/main/docs/patterns.md) — Common MCP Apps patterns
+- [testing-mcp-apps.md](https://github.com/modelcontextprotocol/ext-apps/blob/main/docs/testing-mcp-apps.md) — Testing with basic-host and real hosts
+- [apps.mdx](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx) — Full protocol spec


### PR DESCRIPTION
This guide covers cross-host portability issues for MCP Apps, including endpoint requirements, metadata formats, size notifications, and debugging tips.

<!-- Provide a brief summary of your changes -->
This guide covers cross-host portability issues for MCP Apps, including endpoint
  requirements, metadata formats, size notifications, and debugging tips.     
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
 While building an MCP App that needed to work across Claude, ChatGPT, and a
  custom web host, I encountered a non-obvious issue: widgets rendered correctly in
   ChatGPT but failed silently in Claude with "MCP error 32600: Session
  terminated", despite successful mcp tool responses."

  After many hours of debugging, I discovered the root cause: my authenticated
  endpoint handled `initialize`, `tools/list`, and `tools/call`, but returned 404
  for `resources/list` and `resources/read`. Claude requires these to fetch widget
  HTML; ChatGPT uses direct URLs instead.

  This information isn't documented anywhere that I am aware of. The existing migration guide covers
  converting from OpenAI to MCP Apps, but not the nuances of supporting multiple
  hosts simultaneously. This guide fills that gap. Related issue: #413

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
 Yes, tested in a production MCP server across the following, with widgets rendering successfully after tool calls:
  - Claude.ai (web) 
  - Claude Desktop
  - ChatGPT web and mobile (OpenAI Apps SDK)
  - Custom web app/ host
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
 None. This is documentation only.
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x ] My code follows the repository's style guidelines
- [x ] New and existing tests pass locally
- [x ] I have added appropriate error handling
- [ x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
  This guide intentionally avoids duplicating content from the existing migration
  guide (`migrate_from_openai_apps.md`). It focuses specifically on cross-host
  compatibility issues that aren't covered elsewhere—particularly the `resources/*`
   endpoint requirement that causes silent failures in Claude.