### PR TITLE
docs: add toolInfo.id alternative for localStorage persistence

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -620,6 +620,29 @@ app.ontoolresult = (result) => {
 // e.g., saveState({ currentPage: 5 });
 ```
 
+**Alternative: using the tool call ID from host context**
+
+If you don't need a server-generated UUID, use {@link types!McpUiHostContext `hostContext.toolInfo.id`} — the JSON-RPC tool call ID — as the storage key directly. No server-side changes needed:
+
+<!-- prettier-ignore -->
+```ts source="./patterns.tsx#persistDataToolCallId"
+// Use the tool call ID as a stable localStorage key — no server-side UUID needed
+const toolCallId = String(app.getHostContext()?.toolInfo?.id ?? "default");
+
+function saveState<T>(state: T): void {
+  if (!toolCallId) return;
+  try { localStorage.setItem(toolCallId, JSON.stringify(state)); } catch {}
+}
+
+function loadState<T>(): T | null {
+  if (!toolCallId) return null;
+  try {
+    const s = localStorage.getItem(toolCallId);
+    return s ? (JSON.parse(s) as T) : null;
+  } catch { return null; }
+}
+```
+
 For state that represents user effort (e.g., saved bookmarks, annotations, custom configurations), consider persisting it server-side using [app-only tools](#tools-that-are-private-to-apps) instead. Pass the `viewUUID` to the app-only tool to scope the saved data to that view instance.
 
 > [!NOTE]

--- a/docs/patterns.tsx
+++ b/docs/patterns.tsx
@@ -426,6 +426,29 @@ function persistViewState(app: App) {
 }
 
 /**
+ * Example: Persisting view state using tool call ID (no server-side UUID needed)
+ */
+function persistViewStateWithToolCallId(app: App) {
+  //#region persistDataToolCallId
+  // Use the tool call ID as a stable localStorage key — no server-side UUID needed
+  const toolCallId = String(app.getHostContext()?.toolInfo?.id ?? "default");
+
+  function saveState<T>(state: T): void {
+    if (!toolCallId) return;
+    try { localStorage.setItem(toolCallId, JSON.stringify(state)); } catch {}
+  }
+
+  function loadState<T>(): T | null {
+    if (!toolCallId) return null;
+    try {
+      const s = localStorage.getItem(toolCallId);
+      return s ? (JSON.parse(s) as T) : null;
+    } catch { return null; }
+  }
+  //#endregion persistDataToolCallId
+}
+
+/**
  * Example: Pausing computation-heavy views when out of view
  */
 function visibilityBasedPause(


### PR DESCRIPTION
Adds a simpler alternative to the `viewUUID` pattern in the "Persisting view state" section.

Instead of generating a UUID server-side and passing it via `_meta.viewUUID`, developers can use `app.getHostContext()?.toolInfo.id` — the JSON-RPC tool call ID — as the localStorage key directly.

**When to use this over viewUUID:**
- No server-side changes needed
- `toolInfo.id` is stable across page reloads (same tool call = same ID)
- Simpler setup for basic state persistence

Adds both the `patterns.md` documentation and the type-checked `patterns.tsx` code sample.