### PR TITLE
Work around `tsx watch` hang on Windows in quickstart

### DIFF
--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc --noEmit && tsc -p tsconfig.server.json && cross-env INPUT=mcp-app.html vite build",
-    "start": "concurrently \"cross-env NODE_ENV=development INPUT=mcp-app.html vite build --watch\" \"tsx watch main.ts\""
+    "start": "concurrently --raw \"cross-env NODE_ENV=development INPUT=mcp-app.html vite build --watch\" \"tsx watch main.ts\""
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.0.0",

--- a/examples/quickstart/vite.config.ts
+++ b/examples/quickstart/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { createLogger, defineConfig } from "vite";
 import { viteSingleFile } from "vite-plugin-singlefile";
 
 const INPUT = process.env.INPUT;
@@ -8,7 +8,14 @@ if (!INPUT) {
 
 const isDevelopment = process.env.NODE_ENV === "development";
 
+const prefixedLogger = createLogger();
+for (const level of ["info", "warn", "error"] as const) {
+  const fn = prefixedLogger[level];
+  prefixedLogger[level] = (msg, opts) => fn(msg.replace(/^/mg, "[vite] "), opts);
+}
+
 export default defineConfig({
+  customLogger: prefixedLogger,
   plugins: [viteSingleFile()],
   build: {
     sourcemap: isDevelopment ? "inline" : undefined,


### PR DESCRIPTION
On Windows, `tsx watch` can hang when running under `concurrently` due to stdin handling conflicts (see https://github.com/privatenumber/tsx/issues/623). Adding the `--raw` flag to `concurrently` avoids this by preventing stdin interception.

Since `--raw` mode disables concurrently's automatic output prefixing, a custom Vite logger is added to prefix messages with `[vite]` so users can still distinguish which process produced each line of output.
