### PR TITLE
fix(examples): resolve CSP 'unsafe-eval' violation in threejs-server

### DIFF
--- a/examples/threejs-server/src/threejs-app.tsx
+++ b/examples/threejs-server/src/threejs-app.tsx
@@ -178,16 +178,38 @@ async function executeThreeCode(
   height: number,
   visibilityAwareRAF: (callback: FrameRequestCallback) => number,
 ): Promise<void> {
-  const fn = new Function(
-    "ctx",
-    "canvas",
-    "width",
-    "height",
-    "requestAnimationFrame",
-    `const { THREE, OrbitControls, EffectComposer, RenderPass, UnrealBloomPass } = ctx;
-     return (async () => { ${code} })();`,
-  );
-  await fn(threeContext, canvas, width, height, visibilityAwareRAF);
+  // Use a unique ID to avoid conflicts
+  const scriptId = `threejs_ctx_${Math.random().toString(36).slice(2, 11)}`;
+
+  // Expose context to window temporarily so the script tag can access it
+  (window as any)[scriptId] = {
+    threeContext,
+    canvas,
+    width,
+    height,
+    visibilityAwareRAF,
+  };
+
+  const wrappedCode = `
+    (async () => {
+      const { threeContext, canvas, width, height, visibilityAwareRAF } = window['${scriptId}'];
+      const { THREE, OrbitControls, EffectComposer, RenderPass, UnrealBloomPass } = threeContext;
+      const requestAnimationFrame = visibilityAwareRAF;
+      
+      try {
+        ${code}
+      } catch (e) {
+        console.error('Three.js execution error:', e);
+      } finally {
+        delete window['${scriptId}'];
+      }
+    })();
+  `;
+
+  const script = document.createElement("script");
+  script.textContent = wrappedCode;
+  document.head.appendChild(script);
+  script.remove();
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary of changes
Replaced `new Function()` with a dynamic `<script>` tag execution pattern in the `threejs-server` example's `executeThreeCode` function.

## Motivation and Context
Strict Content Security Policies (CSP) often block `unsafe-eval`, which prevents the use of `new Function()`. This caused the Three.js example to fail in environments like the VS Code MCP App host with the error: 
`"Evaluating a string as JavaScript violates the following Content Security Policy directive..."`. 

By switching to dynamic script injection and a temporary global context object, the app can execute LLM-generated 3D code while adhering to `unsafe-inline` policies, significantly improving compatibility with secure hosts.

## How Has This Been Tested?
- Verified rendering of a 3D rotating cube in a CSP-restricted host.
- Confirmed that the `unsafe-eval` error is no longer triggered.
- Successful build via `npm run build` in `examples/threejs-server`.
- Code style verified with `npm run prettier:fix`.

## Breaking Changes
None. This is an internal implementation change for the example renderer.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
The implementation uses a unique window-level ID (`threejs_ctx_...`) to pass the execution context (THREE, canvas, etc.) to the dynamic script without collisions. The global reference is deleted immediately after execution to keep the environment clean.