### PR TITLE
Change CSP defaults from "MUST" to "SHOULD"

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -281,7 +281,7 @@ When `_meta.ui` is present on **both**, the content-item value takes precedence.
 #### Host Behavior:
 
 - **CSP Enforcement:** Host MUST construct CSP headers based on declared domains
-- **Restrictive Default:** If `ui.csp` is omitted, Host MUST use:
+- **Restrictive Default:** If `ui.csp` is omitted, Host SHOULD use:
 
   ```
   default-src 'none';


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

In ChatGPT, we have security risk-accepted and shipped a slightly looser default CSP. We have a default domain allowlist that includes e.g. `cdn.tailwindcss.com`, `cdn.jsdelivr.net`, `*.oaiusercontent.com`,… that we add to the resourceDomains and connectDomains. We also set `frame-src 'none'` and `default-src 'self'` by default

In order to stay compliant with the spec, we're proposing an update to the spec language around the default CSP from "MUST" to "SHOULD".

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

ChatGPT shipped this default with the Apps SDK many months ago.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No.