### PR TITLE
Rename skill to 'create-mcp-app' to align with spec

### DIFF
--- a/plugins/mcp-apps/skills/create-mcp-app/SKILL.md
+++ b/plugins/mcp-apps/skills/create-mcp-app/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Create MCP App
+name: create-mcp-app
 description: This skill should be used when the user asks to "create an MCP App", "add a UI to an MCP tool", "build an interactive MCP View", "scaffold an MCP App", or needs guidance on MCP Apps SDK patterns, UI-resource registration, MCP App lifecycle, or host integration. Provides comprehensive guidance for building MCP Apps with interactive UIs.
 ---
 


### PR DESCRIPTION
As per the spec (https://agentskills.io/specification) `name` should be:

 "Max 64 characters. *Lowercase letters*, numbers, and *hyphens* only. Must not start or end with a hyphen."

## Motivation and Context
currently throws benign errors/warnings in downstream skills ecosystem tooling Eg. skills.sh, coding agents

## How Has This Been Tested?
simple name change, avoids 

## Breaking Changes
no

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ x] My code follows the repository's style guidelines
- [ x] New and existing tests pass locally
- [ x] I have added appropriate error handling
- [ x] I have added or updated documentation as needed

## Additional context
-
