### PR TITLE
Rename `migrate-oai-app` skill `name` to align with spec

### DIFF
--- a/plugins/mcp-apps/skills/migrate-oai-app/SKILL.md
+++ b/plugins/mcp-apps/skills/migrate-oai-app/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Migrate from OpenAI App
+name: migrate-oai-app
 description: This skill should be used when the user asks to "migrate from OpenAI Apps SDK", "convert OpenAI App to MCP", "port from window.openai", "migrate from skybridge", "convert openai/outputTemplate", or needs guidance on converting OpenAI Apps SDK applications to MCP Apps SDK. Provides step-by-step migration guidance with API mapping tables.
 ---
 


### PR DESCRIPTION
The skill name spec requires lowercase letters, numbers, and hyphens only. Change `name` from "Migrate from OpenAI App" to `migrate-oai-app`.

Companion to #443, which does the same for the `create-mcp-app` skill.
