### PR TITLE
Handle non-JSON-RPC messages gracefully in PostMessageTransport

### DIFF
--- a/src/message-transport.ts
+++ b/src/message-transport.ts
@@ -82,7 +82,17 @@ export class PostMessageTransport implements Transport {
       if (parsed.success) {
         console.debug("Parsed message", parsed.data);
         this.onmessage?.(parsed.data);
+      } else if (event.data?.jsonrpc !== "2.0") {
+        // Not a JSON-RPC message at all (e.g. internal frames injected by
+        // the host environment). Ignore silently so the transport stays alive.
+        console.debug(
+          "Ignoring non-JSON-RPC message",
+          parsed.error.message,
+          event,
+        );
       } else {
+        // Has jsonrpc: "2.0" but is otherwise malformed — surface as a real
+        // protocol error.
         console.error("Failed to parse message", parsed.error.message, event);
         this.onerror?.(
           new Error(


### PR DESCRIPTION
## Summary

Changed `PostMessageTransport` to gracefully ignore non-JSON-RPC messages instead of treating them as transport errors. This prevents the connection from being closed when the host environment injects messages (e.g., `auth_token`) that don't conform to the JSON-RPC format.

Previously, any non-JSON-RPC message would trigger an error callback that could close the iframe connection and prevent subsequent tool-result notifications from being received.

Aims to address https://github.com/anthropics/claude-ai-mcp/issues/47
