### PR TITLE
Add validation for callServerTool params argument

### DIFF
--- a/examples/pdf-server/README.md
+++ b/examples/pdf-server/README.md
@@ -63,7 +63,10 @@ On some host platforms, tool calls have size limits, so large PDFs cannot be sen
 ```typescript
 // Load in chunks with progress
 while (hasMore) {
-  const chunk = await app.callServerTool("read_pdf_bytes", { url, offset });
+  const chunk = await app.callServerTool({
+    name: "read_pdf_bytes",
+    arguments: { url, offset },
+  });
   chunks.push(base64ToBytes(chunk.bytes));
   offset += chunk.byteCount;
   hasMore = chunk.hasMore;

--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -678,6 +678,19 @@ describe("App <-> AppBridge integration", () => {
       expect(result.content).toEqual(resultContent);
     });
 
+    it("callServerTool throws a helpful error when called with a string instead of params object", async () => {
+      await bridge.connect(bridgeTransport);
+      await app.connect(appTransport);
+
+      await expect(
+        // @ts-expect-error intentionally testing wrong usage
+        app.callServerTool("my_tool"),
+      ).rejects.toThrow(
+        'callServerTool() expects an object as its first argument, but received a string ("my_tool"). ' +
+          'Did you mean: callServerTool({ name: "my_tool", arguments: { ... } })?',
+      );
+    });
+
     it("onlistresources setter registers handler for resources/list requests", async () => {
       const requestParams = {};
       const resources = [{ uri: "test://resource", name: "Test" }];

--- a/src/app.ts
+++ b/src/app.ts
@@ -724,6 +724,12 @@ export class App extends Protocol<AppRequest, AppNotification, AppResult> {
     params: CallToolRequest["params"],
     options?: RequestOptions,
   ): Promise<CallToolResult> {
+    if (typeof params === "string") {
+      throw new Error(
+        `callServerTool() expects an object as its first argument, but received a string ("${params}"). ` +
+          `Did you mean: callServerTool({ name: "${params}", arguments: { ... } })?`,
+      );
+    }
     return await this.request(
       { method: "tools/call", params },
       CallToolResultSchema,


### PR DESCRIPTION
## Summary
Added input validation to `callServerTool()` to catch a common usage error where developers pass a string tool name instead of the required params object ( examples: [report 1](https://github.com/anthropics/claude-ai-mcp/issues/32), [report 2](https://github.com/modelcontextprotocol/ext-apps/issues/386)). When this mistake occurs, the method now throws a helpful error message with a suggestion for the correct usage pattern.

## Changes
- **src/app.ts**: Added type check in `callServerTool()` to detect when a string is passed as the first argument and throw a descriptive error with usage guidance
- **src/app-bridge.test.ts**: Added test case verifying the error is thrown with the correct message when `callServerTool()` is called with a string
- **examples/pdf-server/README.md**: Updated code example to use the correct `callServerTool()` API with params object instead of separate arguments

## Implementation Details
The validation checks if the `params` argument is a string and throws an error that:
- Clearly states what was received (the string value)
- Explains what was expected (an object)
- Provides a concrete example of the correct usage pattern with the tool name and arguments structure

https://claude.ai/code/session_01GqAyN4Ux7svWoU2HqsSLZF