### PR TITLE
fix: add audio/video support for basic-host

### DIFF
--- a/examples/basic-host/serve.ts
+++ b/examples/basic-host/serve.ts
@@ -82,6 +82,8 @@ function buildCspHeader(csp?: McpUiResourceCsp): string {
     `img-src 'self' data: blob: ${resourceDomains}`.trim(),
     // Fonts: same-origin + data/blob URIs + specified domains
     `font-src 'self' data: blob: ${resourceDomains}`.trim(),
+    // Media (audio/video): same-origin + data/blob URIs + specified domains
+    `media-src 'self' data: blob: ${resourceDomains}`.trim(),
     // Network requests: same-origin + specified API/tile domains
     `connect-src 'self' ${connectDomains}`.trim(),
     // Workers: same-origin + blob (dynamic workers) + specified domains


### PR DESCRIPTION
Video Example fails on basic-host due to CSP

## Motivation and Context
<img width="1728" height="788" alt="image" src="https://github.com/user-attachments/assets/a899b1b7-44cc-4886-8720-bb6bf972fed3" />

## How Has This Been Tested?
basic-host

<img width="1728" height="905" alt="image" src="https://github.com/user-attachments/assets/5891e4e2-093e-455f-95bc-4c30271c41a6" />


## Breaking Changes
nope

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
