### PR TITLE
feat: MCP app sampling support

### DIFF
--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -79,6 +79,9 @@ import {
   McpUiRequestDisplayModeResult,
   McpUiResourcePermissions,
   McpUiToolMeta,
+  McpUiSamplingCreateMessageRequest,
+  McpUiSamplingCreateMessageRequestSchema,
+  McpUiSamplingCreateMessageResult,
 } from "./types";
 export * from "./types";
 export { RESOURCE_URI_META_KEY, RESOURCE_MIME_TYPE } from "./app";
@@ -731,6 +734,64 @@ export class AppBridge extends Protocol<
   ) {
     this.setRequestHandler(
       McpUiUpdateModelContextRequestSchema,
+      async (request, extra) => {
+        return callback(request.params, extra);
+      },
+    );
+  }
+
+  /**
+   * Register a handler for sampling/createMessage requests from the view.
+   *
+   * The view sends `sampling/createMessage` requests when it needs an LLM
+   * completion. The host fulfills the request using its configured LLM provider.
+   * This handler is only called if the host advertises `sampling` in its
+   * capabilities during initialization.
+   *
+   * The handler receives the conversation messages, an optional system prompt,
+   * and an optional max token limit, and should return the LLM's response.
+   *
+   * **Security considerations:**
+   * - Hosts SHOULD implement rate limiting to prevent abuse
+   * - Hosts SHOULD apply content filtering/moderation policies
+   * - Hosts SHOULD log sampling requests for audit purposes
+   * - Hosts MAY enforce cost management controls (e.g., per-session token budgets)
+   *
+   * @param callback - Handler that receives sampling params and returns a result
+   *   - `params.messages` - Conversation messages providing context
+   *   - `params.systemPrompt` - Optional system prompt to guide LLM behavior
+   *   - `params.maxTokens` - Optional maximum number of tokens to generate
+   *   - `extra` - Request metadata (abort signal, session info)
+   *   - Returns: `Promise<McpUiSamplingCreateMessageResult>` with model, role, content, and stopReason
+   *
+   * @example
+   * ```typescript
+   * bridge.oncreatesamplingmessage = async ({ messages, systemPrompt, maxTokens }, extra) => {
+   *   const response = await llmProvider.createCompletion({
+   *     messages,
+   *     systemPrompt,
+   *     maxTokens: maxTokens ?? 1024,
+   *   });
+   *   return {
+   *     model: response.model,
+   *     stopReason: response.stopReason,
+   *     role: "assistant",
+   *     content: { type: "text", text: response.text },
+   *   };
+   * };
+   * ```
+   *
+   * @see {@link McpUiSamplingCreateMessageRequest `McpUiSamplingCreateMessageRequest`} for the request type
+   * @see {@link McpUiSamplingCreateMessageResult `McpUiSamplingCreateMessageResult`} for the result type
+   */
+  set oncreatesamplingmessage(
+    callback: (
+      params: McpUiSamplingCreateMessageRequest["params"],
+      extra: RequestHandlerExtra,
+    ) => Promise<McpUiSamplingCreateMessageResult>,
+  ) {
+    this.setRequestHandler(
+      McpUiSamplingCreateMessageRequestSchema,
       async (request, extra) => {
         return callback(request.params, extra);
       },

--- a/src/app.ts
+++ b/src/app.ts
@@ -47,6 +47,8 @@ import {
   McpUiToolResultNotificationSchema,
   McpUiRequestDisplayModeRequest,
   McpUiRequestDisplayModeResultSchema,
+  McpUiSamplingCreateMessageRequest,
+  McpUiSamplingCreateMessageResultSchema,
 } from "./types";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
@@ -966,6 +968,75 @@ export class App extends Protocol<AppRequest, AppNotification, AppResult> {
         params,
       },
       McpUiRequestDisplayModeResultSchema,
+      options,
+    );
+  }
+
+  /**
+   * Request an LLM completion from the host.
+   *
+   * Sends a `sampling/createMessage` request to the host, which fulfills it
+   * using its configured LLM provider. This enables Views to leverage the
+   * host's language model capabilities without needing direct API access.
+   *
+   * The host must advertise `sampling` in its capabilities during initialization
+   * for this method to succeed. Check capabilities before calling:
+   *
+   * ```typescript
+   * if (app.getHostCapabilities()?.sampling) {
+   *   const result = await app.createSamplingMessage({ ... });
+   * }
+   * ```
+   *
+   * @param params - Sampling request parameters
+   *   - `messages` - Conversation messages providing context for the completion
+   *   - `systemPrompt` - Optional system prompt to guide LLM behavior
+   *   - `maxTokens` - Optional maximum number of tokens to generate
+   * @param options - Request options (timeout, abort signal, etc.)
+   * @returns Result containing the LLM's response with model info, role, content, and stop reason
+   *
+   * @throws {McpError} With `MethodNotFound` code if the host does not support sampling
+   * @throws {McpError} With `InvalidRequest` code if the request is malformed
+   * @throws {Error} If the request times out or the connection is lost
+   *
+   * @example Basic text completion
+   * ```typescript
+   * const result = await app.createSamplingMessage({
+   *   messages: [
+   *     { role: "user", content: { type: "text", text: "Summarize this data" } },
+   *   ],
+   *   maxTokens: 512,
+   * });
+   * console.log(result.content.text);
+   * ```
+   *
+   * @example Multi-turn conversation with system prompt
+   * ```typescript
+   * const result = await app.createSamplingMessage({
+   *   messages: [
+   *     { role: "user", content: { type: "text", text: "What is 2+2?" } },
+   *     { role: "assistant", content: { type: "text", text: "4" } },
+   *     { role: "user", content: { type: "text", text: "And 3+3?" } },
+   *   ],
+   *   systemPrompt: "You are a helpful math tutor.",
+   *   maxTokens: 256,
+   * });
+   * ```
+   *
+   * @see {@link McpUiSamplingCreateMessageRequest `McpUiSamplingCreateMessageRequest`} for the request type
+   * @see {@link McpUiSamplingCreateMessageResult `McpUiSamplingCreateMessageResult`} for the result type
+   * @see {@link McpUiHostCapabilities `McpUiHostCapabilities`} for checking sampling support
+   */
+  createSamplingMessage(
+    params: McpUiSamplingCreateMessageRequest["params"],
+    options?: RequestOptions,
+  ) {
+    return this.request(
+      <McpUiSamplingCreateMessageRequest>{
+        method: "sampling/createMessage",
+        params,
+      },
+      McpUiSamplingCreateMessageResultSchema,
       options,
     );
   }

--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -283,6 +283,29 @@
             }
           },
           "additionalProperties": false
+        },
+        "sampling": {
+          "description": "Host can fulfill sampling requests (sampling/createMessage) from the View.",
+          "type": "object",
+          "properties": {
+            "supportedModalities": {
+              "description": "Supported content modalities for sampling messages (default: [\"text\"]).",
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "text"
+                  },
+                  {
+                    "type": "string",
+                    "const": "image"
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -2629,6 +2652,29 @@
                 }
               },
               "additionalProperties": false
+            },
+            "sampling": {
+              "description": "Host can fulfill sampling requests (sampling/createMessage) from the View.",
+              "type": "object",
+              "properties": {
+                "supportedModalities": {
+                  "description": "Supported content modalities for sampling messages (default: [\"text\"]).",
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "const": "text"
+                      },
+                      {
+                        "type": "string",
+                        "const": "image"
+                      }
+                    ]
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false,
@@ -4040,6 +4086,186 @@
         "type": "string"
       },
       "additionalProperties": {}
+    },
+    "McpUiSamplingCreateMessageRequest": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "const": "sampling/createMessage"
+        },
+        "params": {
+          "type": "object",
+          "properties": {
+            "messages": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "role": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "const": "user"
+                      },
+                      {
+                        "type": "string",
+                        "const": "assistant"
+                      }
+                    ],
+                    "description": "The role of the message sender."
+                  },
+                  "content": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "text"
+                          },
+                          "text": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["type", "text"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "image"
+                          },
+                          "data": {
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["type", "data", "mimeType"],
+                        "additionalProperties": false
+                      }
+                    ],
+                    "description": "The content of the message."
+                  }
+                },
+                "required": ["role", "content"],
+                "additionalProperties": false
+              },
+              "description": "Conversation messages providing context for the completion."
+            },
+            "systemPrompt": {
+              "description": "Optional system prompt to guide the LLM's behavior.",
+              "type": "string"
+            },
+            "maxTokens": {
+              "description": "Optional maximum number of tokens to generate.",
+              "type": "number"
+            }
+          },
+          "required": ["messages"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["method", "params"],
+      "additionalProperties": false
+    },
+    "McpUiSamplingCreateMessageResult": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "The model that generated the completion."
+        },
+        "stopReason": {
+          "type": "string",
+          "description": "The reason the model stopped generating (e.g., \"endTurn\", \"maxTokens\")."
+        },
+        "role": {
+          "type": "string",
+          "const": "assistant",
+          "description": "The role of the generated message (always \"assistant\")."
+        },
+        "content": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "text"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": ["type", "text"],
+          "additionalProperties": false,
+          "description": "The generated content."
+        }
+      },
+      "required": ["model", "stopReason", "role", "content"],
+      "additionalProperties": {}
+    },
+    "McpUiSamplingMessage": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "role": {
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "user"
+            },
+            {
+              "type": "string",
+              "const": "assistant"
+            }
+          ],
+          "description": "The role of the message sender."
+        },
+        "content": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "text"
+                },
+                "text": {
+                  "type": "string"
+                }
+              },
+              "required": ["type", "text"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "image"
+                },
+                "data": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                }
+              },
+              "required": ["type", "data", "mimeType"],
+              "additionalProperties": false
+            }
+          ],
+          "description": "The content of the message."
+        }
+      },
+      "required": ["role", "content"],
+      "additionalProperties": false
     },
     "McpUiSandboxProxyReadyNotification": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/generated/schema.test.ts
+++ b/src/generated/schema.test.ts
@@ -103,6 +103,18 @@ export type McpUiResourceMetaSchemaInferredType = z.infer<
   typeof generated.McpUiResourceMetaSchema
 >;
 
+export type McpUiSamplingMessageSchemaInferredType = z.infer<
+  typeof generated.McpUiSamplingMessageSchema
+>;
+
+export type McpUiSamplingCreateMessageRequestSchemaInferredType = z.infer<
+  typeof generated.McpUiSamplingCreateMessageRequestSchema
+>;
+
+export type McpUiSamplingCreateMessageResultSchemaInferredType = z.infer<
+  typeof generated.McpUiSamplingCreateMessageResultSchema
+>;
+
 export type McpUiRequestDisplayModeRequestSchemaInferredType = z.infer<
   typeof generated.McpUiRequestDisplayModeRequestSchema
 >;
@@ -261,6 +273,24 @@ expectType<McpUiInitializedNotificationSchemaInferredType>(
 );
 expectType<spec.McpUiResourceMeta>({} as McpUiResourceMetaSchemaInferredType);
 expectType<McpUiResourceMetaSchemaInferredType>({} as spec.McpUiResourceMeta);
+expectType<spec.McpUiSamplingMessage>(
+  {} as McpUiSamplingMessageSchemaInferredType,
+);
+expectType<McpUiSamplingMessageSchemaInferredType>(
+  {} as spec.McpUiSamplingMessage,
+);
+expectType<spec.McpUiSamplingCreateMessageRequest>(
+  {} as McpUiSamplingCreateMessageRequestSchemaInferredType,
+);
+expectType<McpUiSamplingCreateMessageRequestSchemaInferredType>(
+  {} as spec.McpUiSamplingCreateMessageRequest,
+);
+expectType<spec.McpUiSamplingCreateMessageResult>(
+  {} as McpUiSamplingCreateMessageResultSchemaInferredType,
+);
+expectType<McpUiSamplingCreateMessageResultSchemaInferredType>(
+  {} as spec.McpUiSamplingCreateMessageResult,
+);
 expectType<spec.McpUiRequestDisplayModeRequest>(
   {} as McpUiRequestDisplayModeRequestSchemaInferredType,
 );

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -523,6 +523,21 @@ export const McpUiHostCapabilitiesSchema = z.object({
   message: McpUiSupportedContentBlockModalitiesSchema.optional().describe(
     "Host supports receiving content messages (ui/message) from the view.",
   ),
+  /** @description Host can fulfill sampling requests (sampling/createMessage) from the View. */
+  sampling: z
+    .object({
+      /** @description Supported content modalities for sampling messages (default: ["text"]). */
+      supportedModalities: z
+        .array(z.union([z.literal("text"), z.literal("image")]))
+        .optional()
+        .describe(
+          'Supported content modalities for sampling messages (default: ["text"]).',
+        ),
+    })
+    .optional()
+    .describe(
+      "Host can fulfill sampling requests (sampling/createMessage) from the View.",
+    ),
 });
 
 /**
@@ -617,6 +632,92 @@ export const McpUiResourceMetaSchema = z.object({
       "Visual boundary preference - true if view prefers a visible border.\n\nBoolean requesting whether a visible border and background is provided by the host. Specifying an explicit value for this is recommended because hosts' defaults may vary.\n\n- `true`: request visible border + background\n- `false`: request no visible border + background\n- omitted: host decides border",
     ),
 });
+
+/**
+ * @description A message in a sampling conversation.
+ *
+ * Used as input to `sampling/createMessage` requests. Each message has a role
+ * (user or assistant) and content that can be text or image.
+ */
+export const McpUiSamplingMessageSchema = z.object({
+  /** @description The role of the message sender. */
+  role: z
+    .union([z.literal("user"), z.literal("assistant")])
+    .describe("The role of the message sender."),
+  /** @description The content of the message. */
+  content: z
+    .union([
+      z.object({
+        type: z.literal("text"),
+        text: z.string(),
+      }),
+      z.object({
+        type: z.literal("image"),
+        data: z.string(),
+        mimeType: z.string(),
+      }),
+    ])
+    .describe("The content of the message."),
+});
+
+/**
+ * @description Request to create a sampling message (LLM completion) from the host.
+ *
+ * The View sends this request when it needs an LLM completion. The host
+ * fulfills the request using its configured LLM provider. The host MAY
+ * enforce rate limits, content filtering, and cost controls.
+ *
+ * Requires the host to advertise `sampling` in its capabilities.
+ *
+ * @see {@link app!App.createSamplingMessage `App.createSamplingMessage`} for the method that sends this request
+ */
+export const McpUiSamplingCreateMessageRequestSchema = z.object({
+  method: z.literal("sampling/createMessage"),
+  params: z.object({
+    /** @description Conversation messages providing context for the completion. */
+    messages: z
+      .array(McpUiSamplingMessageSchema)
+      .describe("Conversation messages providing context for the completion."),
+    /** @description Optional system prompt to guide the LLM's behavior. */
+    systemPrompt: z
+      .string()
+      .optional()
+      .describe("Optional system prompt to guide the LLM's behavior."),
+    /** @description Optional maximum number of tokens to generate. */
+    maxTokens: z
+      .number()
+      .optional()
+      .describe("Optional maximum number of tokens to generate."),
+  }),
+});
+
+/**
+ * @description Result from a sampling/createMessage request.
+ * @see {@link McpUiSamplingCreateMessageRequest `McpUiSamplingCreateMessageRequest`}
+ */
+export const McpUiSamplingCreateMessageResultSchema = z
+  .object({
+    /** @description The model that generated the completion. */
+    model: z.string().describe("The model that generated the completion."),
+    /** @description The reason the model stopped generating (e.g., "endTurn", "maxTokens"). */
+    stopReason: z
+      .string()
+      .describe(
+        'The reason the model stopped generating (e.g., "endTurn", "maxTokens").',
+      ),
+    /** @description The role of the generated message (always "assistant"). */
+    role: z
+      .literal("assistant")
+      .describe('The role of the generated message (always "assistant").'),
+    /** @description The generated content. */
+    content: z
+      .object({
+        type: z.literal("text"),
+        text: z.string(),
+      })
+      .describe("The generated content."),
+  })
+  .passthrough();
 
 /**
  * @description Request to change the display mode of the UI.

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -473,6 +473,11 @@ export interface McpUiHostCapabilities {
   updateModelContext?: McpUiSupportedContentBlockModalities;
   /** @description Host supports receiving content messages (ui/message) from the view. */
   message?: McpUiSupportedContentBlockModalities;
+  /** @description Host can fulfill sampling requests (sampling/createMessage) from the View. */
+  sampling?: {
+    /** @description Supported content modalities for sampling messages (default: ["text"]). */
+    supportedModalities?: Array<"text" | "image">;
+  };
 }
 
 /**
@@ -675,6 +680,64 @@ export interface McpUiResourceMeta {
 }
 
 /**
+ * @description A message in a sampling conversation.
+ *
+ * Used as input to `sampling/createMessage` requests. Each message has a role
+ * (user or assistant) and content that can be text or image.
+ */
+export interface McpUiSamplingMessage {
+  /** @description The role of the message sender. */
+  role: "user" | "assistant";
+  /** @description The content of the message. */
+  content:
+    | { type: "text"; text: string }
+    | { type: "image"; data: string; mimeType: string };
+}
+
+/**
+ * @description Request to create a sampling message (LLM completion) from the host.
+ *
+ * The View sends this request when it needs an LLM completion. The host
+ * fulfills the request using its configured LLM provider. The host MAY
+ * enforce rate limits, content filtering, and cost controls.
+ *
+ * Requires the host to advertise `sampling` in its capabilities.
+ *
+ * @see {@link app!App.createSamplingMessage `App.createSamplingMessage`} for the method that sends this request
+ */
+export interface McpUiSamplingCreateMessageRequest {
+  method: "sampling/createMessage";
+  params: {
+    /** @description Conversation messages providing context for the completion. */
+    messages: McpUiSamplingMessage[];
+    /** @description Optional system prompt to guide the LLM's behavior. */
+    systemPrompt?: string;
+    /** @description Optional maximum number of tokens to generate. */
+    maxTokens?: number;
+  };
+}
+
+/**
+ * @description Result from a sampling/createMessage request.
+ * @see {@link McpUiSamplingCreateMessageRequest `McpUiSamplingCreateMessageRequest`}
+ */
+export interface McpUiSamplingCreateMessageResult {
+  /** @description The model that generated the completion. */
+  model: string;
+  /** @description The reason the model stopped generating (e.g., "endTurn", "maxTokens"). */
+  stopReason: string;
+  /** @description The role of the generated message (always "assistant"). */
+  role: "assistant";
+  /** @description The generated content. */
+  content: { type: "text"; text: string };
+  /**
+   * Index signature required for MCP SDK `Protocol` class compatibility.
+   * Note: The generated schema uses passthrough() to allow additional properties.
+   */
+  [key: string]: unknown;
+}
+
+/**
  * @description Request to change the display mode of the UI.
  * The host will respond with the actual display mode that was set,
  * which may differ from the requested mode if not supported.
@@ -771,6 +834,8 @@ export const INITIALIZED_METHOD: McpUiInitializedNotification["method"] =
   "ui/notifications/initialized";
 export const REQUEST_DISPLAY_MODE_METHOD: McpUiRequestDisplayModeRequest["method"] =
   "ui/request-display-mode";
+export const SAMPLING_CREATE_MESSAGE_METHOD: McpUiSamplingCreateMessageRequest["method"] =
+  "sampling/createMessage";
 
 /**
  * @description MCP Apps capability settings advertised by clients to servers.

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export {
   INITIALIZE_METHOD,
   INITIALIZED_METHOD,
   REQUEST_DISPLAY_MODE_METHOD,
+  SAMPLING_CREATE_MESSAGE_METHOD,
   type McpUiTheme,
   type McpUiDisplayMode,
   type McpUiStyleVariableKey,
@@ -62,6 +63,9 @@ export {
   type McpUiToolVisibility,
   type McpUiToolMeta,
   type McpUiClientCapabilities,
+  type McpUiSamplingMessage,
+  type McpUiSamplingCreateMessageRequest,
+  type McpUiSamplingCreateMessageResult,
 } from "./spec.types.js";
 
 // Import types needed for protocol type unions (not re-exported, just used internally)
@@ -72,6 +76,8 @@ import type {
   McpUiUpdateModelContextRequest,
   McpUiResourceTeardownRequest,
   McpUiRequestDisplayModeRequest,
+  McpUiSamplingCreateMessageRequest,
+  McpUiSamplingCreateMessageResult,
   McpUiHostContextChangedNotification,
   McpUiToolInputNotification,
   McpUiToolInputPartialNotification,
@@ -123,6 +129,9 @@ export {
   McpUiRequestDisplayModeResultSchema,
   McpUiToolVisibilitySchema,
   McpUiToolMetaSchema,
+  McpUiSamplingMessageSchema,
+  McpUiSamplingCreateMessageRequestSchema,
+  McpUiSamplingCreateMessageResultSchema,
 } from "./generated/schema.js";
 
 // Re-export SDK types used in protocol type unions
@@ -163,6 +172,7 @@ export type AppRequest =
   | McpUiUpdateModelContextRequest
   | McpUiResourceTeardownRequest
   | McpUiRequestDisplayModeRequest
+  | McpUiSamplingCreateMessageRequest
   | CallToolRequest
   | ListToolsRequest
   | ListResourcesRequest
@@ -210,6 +220,7 @@ export type AppResult =
   | McpUiMessageResult
   | McpUiResourceTeardownResult
   | McpUiRequestDisplayModeResult
+  | McpUiSamplingCreateMessageResult
   | CallToolResult
   | ListToolsResult
   | ListResourcesResult


### PR DESCRIPTION
Adds support for MCP apps to sample from the host's model connection, enabling Apps themselves to become AI-powered

See a more detailed proposal here: https://gist.github.com/alexhancock/2bb8b62500f33ccb29a0edb4aa7c5342

## Motivation and Context
The idea is simply to let App code leverage the host's model connection, opening up a range of compelling app experiences (nested agents, specialized visual tutors, image generators, vision-based applications, etc)

## How Has This Been Tested?
This concept has been implemented in goose (https://github.com/block/goose/pull/7039) using the `onFallbackRequest` param, but this change elevates the idea to a first class citizen)

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
This MCP SEP is related as it adds the supported modalities concept to client capabilities as well https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2278. This way we can use the same type in modeling host capabilities re: sampling
