### PR TITLE
pdf: ignore safe area insets in fullscreen mode

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,5 @@ examples/basic-server-*/**/*.ts
 examples/basic-server-*/**/*.tsx
 examples/quickstart/**/*.ts
 **/vendor/**
+**/.build/**
 SKILL.md

--- a/examples/pdf-server/src/mcp-app.css
+++ b/examples/pdf-server/src/mcp-app.css
@@ -325,6 +325,7 @@ body {
   overflow: hidden; /* No scrolling on main - only canvas-container scrolls */
   border-radius: 0;
   border: none;
+  padding: 0 !important; /* Ignore safe area insets in fullscreen */
 }
 
 .main.fullscreen .viewer {


### PR DESCRIPTION
## Summary
- Add `padding: 0 !important` to `.main.fullscreen` in the PDF viewer so that safe area insets (applied as inline styles by `handleHostContextChanged`) are overridden in fullscreen mode
- Makes the PDF viewer truly edge-to-edge when fullscreen
- Also adds `.build` directories to `.prettierignore` to fix pre-commit hook failures caused by Swift build artifacts with restricted permissions

<img width="2874" height="2062" alt="CleanShot 2026-02-21 at 16 24 41@2x" src="https://github.com/user-attachments/assets/98e31cce-bb1c-462b-a0b4-0dfbf76bf5de" />
