### PR TITLE
Set audioSession.type to playback in sheet music app

### DIFF
--- a/examples/sheet-music-server/src/mcp-app.ts
+++ b/examples/sheet-music-server/src/mcp-app.ts
@@ -31,6 +31,17 @@ const sheetMusicEl = document.getElementById("sheet-music")!;
 const audioControlsEl = document.getElementById("audio-controls")!;
 
 // =============================================================================
+// Audio Session
+// =============================================================================
+
+// Declare this app's audio as media playback so the platform can handle it
+// correctly: background audio, lock screen controls, Dynamic Island, and
+// bypassing the iOS silent switch. See https://w3c.github.io/audio-session/
+if ("audioSession" in navigator) {
+  (navigator.audioSession as { type: string }).type = "playback";
+}
+
+// =============================================================================
 // ABC Rendering
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Sets `navigator.audioSession.type = "playback"` in the sheet music MCP app so the platform handles audio as media playback: background audio, lock screen controls, Dynamic Island integration, and bypassing the iOS silent switch.

## Context

The [Audio Session API](https://w3c.github.io/audio-session/) (W3C Working Draft, Safari 16.4+) lets web content declare its audio intent. Without setting the type, audio defaults to `"auto"` which treats it as casual web audio — it stops on background and respects the silent switch.

## Changes

- Added `navigator.audioSession.type = "playback"` early in `src/mcp-app.ts`, before any AudioContext is created
- Guarded behind `"audioSession" in navigator` check for non-Safari browsers