### PR TITLE
ci: build and publish MCPB bundle for pdf-server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
 
       - run: npm run prettier
 
+      - name: Build MCPB bundle (pdf-server)
+        if: runner.os == 'Linux' && matrix.name == 'Linux x64'
+        run: npx -y @anthropic-ai/mcpb pack
+        working-directory: examples/pdf-server
+
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -138,3 +138,35 @@ jobs:
         run: npm publish --workspace examples/${{ matrix.example }} --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
+
+  publish-mcpb:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    environment: Release
+    needs: [publish-examples]
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+      - run: npm ci
+
+      - name: Build pdf-server
+        run: npm run build --workspace examples/pdf-server
+
+      - name: Pack MCPB bundle
+        run: npx -y @anthropic-ai/mcpb pack
+        working-directory: examples/pdf-server
+
+      - name: Upload MCPB to release
+        run: gh release upload "${{ github.event.release.tag_name }}" examples/pdf-server/*.mcpb --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ playwright-report/
 test-results/
 __pycache__/
 *.pyc
+
+# MCPB bundles (built artifacts)
+*.mcpb


### PR DESCRIPTION
## Summary

- Add `*.mcpb` to `.gitignore` (built artifacts, like `dist/`)
- Validate MCPB packaging in CI (`npx -y @anthropic-ai/mcpb pack`, Linux x64 only) to catch broken manifests early
- Build and upload `.mcpb` bundle as a GitHub release asset on publish (`npm-publish.yml`)

## Changes

### `.gitignore`
- Added `*.mcpb` pattern to ignore locally-built bundles

### `.github/workflows/ci.yml`
- Added MCPB pack validation step after existing build/test steps (Linux x64 only to avoid redundant runs)

### `.github/workflows/npm-publish.yml`
- Added `publish-mcpb` job that runs after `publish-examples`, builds the pdf-server, packs the `.mcpb` bundle, and uploads it as a GitHub release asset via `gh release upload --clobber`

## Test Plan
- CI should run the MCPB pack step on Linux x64 and succeed
- On release, the `.mcpb` file should appear as a downloadable asset on the GitHub release page