### PR TITLE
chore: bump ext-apps to 1.1.1

### DIFF
--- a/examples/basic-host/package.json
+++ b/examples/basic-host/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/basic-host",
   "name": "@modelcontextprotocol/ext-apps-basic-host",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && concurrently \"cross-env INPUT=index.html vite build\" \"cross-env INPUT=sandbox.html vite build\"",

--- a/examples/basic-server-preact/package.json
+++ b/examples/basic-server-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-preact",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Basic MCP App Server example using Preact",
   "repository": {

--- a/examples/basic-server-react/package.json
+++ b/examples/basic-server-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Basic MCP App Server example using React",
   "repository": {

--- a/examples/basic-server-solid/package.json
+++ b/examples/basic-server-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-solid",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Basic MCP App Server example using Solid",
   "repository": {

--- a/examples/basic-server-svelte/package.json
+++ b/examples/basic-server-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-svelte",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Basic MCP App Server example using Svelte",
   "repository": {

--- a/examples/basic-server-vanillajs/package.json
+++ b/examples/basic-server-vanillajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-vanillajs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Basic MCP App Server example using vanilla JavaScript",
   "repository": {

--- a/examples/basic-server-vue/package.json
+++ b/examples/basic-server-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-vue",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Basic MCP App Server example using Vue",
   "repository": {

--- a/examples/budget-allocator-server/package.json
+++ b/examples/budget-allocator-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-budget-allocator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Budget allocator MCP App Server with interactive visualization",
   "repository": {

--- a/examples/cohort-heatmap-server/package.json
+++ b/examples/cohort-heatmap-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-cohort-heatmap",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Cohort heatmap MCP App Server for retention analysis",
   "repository": {

--- a/examples/customer-segmentation-server/package.json
+++ b/examples/customer-segmentation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-customer-segmentation",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Customer segmentation MCP App Server with filtering",
   "repository": {

--- a/examples/debug-server/package.json
+++ b/examples/debug-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-debug",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Debug MCP App Server for testing all SDK capabilities",
   "repository": {

--- a/examples/integration-server/package.json
+++ b/examples/integration-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-server",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/map-server/package.json
+++ b/examples/map-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-map",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "MCP App Server example with CesiumJS 3D globe and geocoding",
   "repository": {

--- a/examples/pdf-server/package.json
+++ b/examples/pdf-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-pdf",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "MCP server for loading and extracting text from PDF files with chunked pagination and interactive viewer",
   "repository": {

--- a/examples/qr-server/package.json
+++ b/examples/qr-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-qr",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "start": "uv run server.py",

--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/quickstart",
-  "version": "0.4.1",
+  "version": "1.1.1",
   "type": "module",
   "private": true,
   "description": "Quickstart MCP App Server example",

--- a/examples/say-server/package.json
+++ b/examples/say-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-say",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Streaming TTS MCP App Server with karaoke-style text highlighting",
   "repository": {

--- a/examples/scenario-modeler-server/package.json
+++ b/examples/scenario-modeler-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-scenario-modeler",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Financial scenario modeling MCP App Server",
   "repository": {

--- a/examples/shadertoy-server/package.json
+++ b/examples/shadertoy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-shadertoy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "MCP App Server example for rendering ShaderToy-compatible GLSL shaders",
   "repository": {

--- a/examples/sheet-music-server/package.json
+++ b/examples/sheet-music-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-sheet-music",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "MCP App Server for rendering and playing sheet music from ABC notation",
   "repository": {

--- a/examples/system-monitor-server/package.json
+++ b/examples/system-monitor-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-system-monitor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "System monitor MCP App Server with real-time stats",
   "repository": {

--- a/examples/threejs-server/package.json
+++ b/examples/threejs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-threejs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Three.js 3D visualization MCP App Server",
   "repository": {

--- a/examples/transcript-server/package.json
+++ b/examples/transcript-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-transcript",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "MCP App Server for live speech transcription",
   "repository": {

--- a/examples/video-resource-server/package.json
+++ b/examples/video-resource-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-video-resource",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "MCP App Server demonstrating video resources served as base64 blobs",
   "repository": {

--- a/examples/wiki-explorer-server/package.json
+++ b/examples/wiki-explorer-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-wiki-explorer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Wikipedia link explorer MCP App Server with graph visualization",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/ext-apps",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/ext-apps",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -79,7 +79,7 @@
     },
     "examples/basic-host": {
       "name": "@modelcontextprotocol/ext-apps-basic-host",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.24.0",
@@ -122,7 +122,7 @@
     },
     "examples/basic-server-preact": {
       "name": "@modelcontextprotocol/server-basic-preact",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -166,7 +166,7 @@
     },
     "examples/basic-server-react": {
       "name": "@modelcontextprotocol/server-basic-react",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -213,7 +213,7 @@
     },
     "examples/basic-server-solid": {
       "name": "@modelcontextprotocol/server-basic-solid",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -257,7 +257,7 @@
     },
     "examples/basic-server-svelte": {
       "name": "@modelcontextprotocol/server-basic-svelte",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -301,7 +301,7 @@
     },
     "examples/basic-server-vanillajs": {
       "name": "@modelcontextprotocol/server-basic-vanillajs",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -343,7 +343,7 @@
     },
     "examples/basic-server-vue": {
       "name": "@modelcontextprotocol/server-basic-vue",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -387,7 +387,7 @@
     },
     "examples/budget-allocator-server": {
       "name": "@modelcontextprotocol/server-budget-allocator",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -430,7 +430,7 @@
     },
     "examples/cohort-heatmap-server": {
       "name": "@modelcontextprotocol/server-cohort-heatmap",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -477,7 +477,7 @@
     },
     "examples/customer-segmentation-server": {
       "name": "@modelcontextprotocol/server-customer-segmentation",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -520,7 +520,7 @@
     },
     "examples/debug-server": {
       "name": "@modelcontextprotocol/server-debug",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -561,7 +561,7 @@
       "license": "MIT"
     },
     "examples/integration-server": {
-      "version": "1.0.0",
+      "version": "1.1.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.24.0",
@@ -606,7 +606,7 @@
     },
     "examples/map-server": {
       "name": "@modelcontextprotocol/server-map",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -648,7 +648,7 @@
     },
     "examples/pdf-server": {
       "name": "@modelcontextprotocol/server-pdf",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -691,14 +691,14 @@
     },
     "examples/qr-server": {
       "name": "@modelcontextprotocol/server-qr",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0"
       }
     },
     "examples/quickstart": {
       "name": "@modelcontextprotocol/quickstart",
-      "version": "0.4.1",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -730,7 +730,7 @@
     },
     "examples/say-server": {
       "name": "@modelcontextprotocol/server-say",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0"
@@ -738,7 +738,7 @@
     },
     "examples/scenario-modeler-server": {
       "name": "@modelcontextprotocol/server-scenario-modeler",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -786,7 +786,7 @@
     },
     "examples/shadertoy-server": {
       "name": "@modelcontextprotocol/server-shadertoy",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -828,7 +828,7 @@
     },
     "examples/sheet-music-server": {
       "name": "@modelcontextprotocol/server-sheet-music",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -871,7 +871,7 @@
     },
     "examples/system-monitor-server": {
       "name": "@modelcontextprotocol/server-system-monitor",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -915,7 +915,7 @@
     },
     "examples/threejs-server": {
       "name": "@modelcontextprotocol/server-threejs",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -964,7 +964,7 @@
     },
     "examples/transcript-server": {
       "name": "@modelcontextprotocol/server-transcript",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -1007,7 +1007,7 @@
     },
     "examples/video-resource-server": {
       "name": "@modelcontextprotocol/server-video-resource",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -1049,7 +1049,7 @@
     },
     "examples/wiki-explorer-server": {
       "name": "@modelcontextprotocol/server-wiki-explorer",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/modelcontextprotocol/ext-apps"
   },
   "homepage": "https://github.com/modelcontextprotocol/ext-apps",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "description": "MCP Apps SDK — Enable MCP servers to display interactive user interfaces in conversational clients.",
   "type": "module",


### PR DESCRIPTION
Bug fixes / improvements since 1.1.0:
- fix: add audio/video support for basic-host (#460)
- fix(pdf-server): remove page-loading overlay (#493)
- pdf-server: remove domain allowlist, require HTTPS only (#487)
- Set audioSession.type to playback in sheet music app (#489)
- Add MCPB packaging and Claude Code plugin for pdf-server (#491)