### PR TITLE
ci: auto-fix prettier formatting in pre-commit hook and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,35 @@ permissions:
   contents: read
 
 jobs:
+  prettier-fix:
+    name: Auto-fix formatting
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ github.token }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - run: npm ci
+
+      - run: npm run prettier:fix
+
+      - name: Commit formatting changes
+        run: |
+          git diff --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "style: auto-fix prettier formatting"
+          git push
+
   build:
     strategy:
       fail-fast: false

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,5 +17,5 @@ fi
 npm run build:all
 npm run prettier:fix
 
-# Stage any changes to generated files (they may have been reformatted by prettier)
-git add src/generated/
+# Stage any files reformatted by prettier (generated files, source, docs, etc.)
+git diff --name-only --diff-filter=M | xargs -r git add


### PR DESCRIPTION
## Summary

Automates prettier formatting so contributors don't have to manually iterate on formatting failures.

### Changes

**Pre-commit hook (`.husky/pre-commit`)**
- After running `prettier:fix`, stage **all** modified files (not just `src/generated/`)
- This ensures formatting fixes are included in the commit automatically

**CI (`ci.yml`) — new `prettier-fix` job**
- Runs on PRs from the same repo (skips fork PRs for security — no write access)
- Runs `npm run prettier:fix`
- If there are formatting changes, commits and pushes them back to the PR branch
- Uses `github-actions[bot]` as the commit author

### How it works

1. **Local development**: The pre-commit hook runs prettier and stages any reformatted files, so formatting is always correct before push
2. **CI fallback**: If someone bypasses the hook (e.g., `--no-verify`, GUI client), the CI job auto-fixes and pushes a formatting commit back to the PR branch
3. **Existing check preserved**: The `npm run prettier` check in the `build` job still runs across all platforms as a gate — it will pass after the auto-fix job runs