### PR TITLE
fix: sync local SDK build into node_modules for examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "start": "npm run examples:dev",
     "generate:schemas": "tsx scripts/generate-schemas.ts && prettier --write \"src/generated/**/*\"",
     "sync:snippets": "bun scripts/sync-snippets.ts",
-    "build": "npm run generate:schemas && npm run sync:snippets && node scripts/run-bun.mjs build.bun.ts",
+    "build": "npm run generate:schemas && npm run sync:snippets && node scripts/run-bun.mjs build.bun.ts && node scripts/link-self.mjs",
     "prepack": "npm run build",
     "build:all": "npm run examples:build",
     "test": "bun test src",

--- a/scripts/link-self.mjs
+++ b/scripts/link-self.mjs
@@ -1,0 +1,14 @@
+/**
+ * Workaround: npm workspaces don't symlink the root package into node_modules
+ * when child workspaces depend on it — it installs a stale registry copy instead.
+ * This script syncs the freshly-built dist/ and package.json into that copy
+ * so examples always type-check against the latest local types.
+ * See: https://github.com/npm/feedback/discussions/774
+ */
+import { cpSync, existsSync } from "fs";
+
+const target = "node_modules/@modelcontextprotocol/ext-apps";
+if (!existsSync(target)) process.exit(0);
+
+cpSync("dist", `${target}/dist`, { recursive: true });
+cpSync("package.json", `${target}/package.json`);


### PR DESCRIPTION
npm workspaces hoists example dependencies to root `node_modules/`, but installs the published registry copy of `@modelcontextprotocol/ext-apps` instead of linking to the local source. This causes type-check failures when examples use features not yet published to npm.

Adds `scripts/link-self.mjs` which copies the freshly-built `dist/` and `package.json` into the hoisted `node_modules` copy after each SDK build, ensuring examples always type-check against the latest local types.

See: https://github.com/npm/feedback/discussions/774