### PR TITLE
Remove dev-only platform binaries from optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "examples/*"
   ],
   "scripts": {
-    "postinstall": "node scripts/setup-bun.mjs || echo 'setup-bun.mjs failed or not available'",
     "start": "npm run examples:dev",
     "generate:schemas": "tsx scripts/generate-schemas.ts && prettier --write \"src/generated/**/*\"",
     "sync:snippets": "bun scripts/sync-snippets.ts",
@@ -116,25 +115,6 @@
     "react-dom": {
       "optional": true
     }
-  },
-  "optionalDependencies": {
-    "@oven/bun-darwin-aarch64": "^1.2.21",
-    "@oven/bun-darwin-x64": "^1.2.21",
-    "@oven/bun-darwin-x64-baseline": "^1.2.21",
-    "@oven/bun-linux-aarch64": "^1.2.21",
-    "@oven/bun-linux-aarch64-musl": "^1.2.21",
-    "@oven/bun-linux-x64": "^1.2.21",
-    "@oven/bun-linux-x64-baseline": "^1.2.21",
-    "@oven/bun-linux-x64-musl": "^1.2.21",
-    "@oven/bun-linux-x64-musl-baseline": "^1.2.21",
-    "@oven/bun-windows-x64": "^1.2.21",
-    "@oven/bun-windows-x64-baseline": "^1.2.21",
-    "@rollup/rollup-darwin-arm64": "^4.53.3",
-    "@rollup/rollup-darwin-x64": "^4.53.3",
-    "@rollup/rollup-linux-arm64-gnu": "^4.53.3",
-    "@rollup/rollup-linux-x64-gnu": "^4.53.3",
-    "@rollup/rollup-win32-arm64-msvc": "^4.53.3",
-    "@rollup/rollup-win32-x64-msvc": "^4.53.3"
   },
   "overrides": {
     "seroval": "1.4.1",


### PR DESCRIPTION
## Summary

Fixes https://github.com/modelcontextprotocol/ext-apps/issues/222, removes `@oven/bun-*` and `@rollup/rollup-*` from `optionalDependencies` entirely, and removes the redundant `postinstall` script.

Builds on the investigation from #451, thanks @ochafik! This is a simpler alternative to #516.

## Context

At Datadog we're building on MCP Apps and this `optionalDependencies` bloat (~400MB of platform binaries) is blocking our CI pipelines, which motivated picking this up.

## Why #451's approach doesn't work

#451 moved the platform binaries from `optionalDependencies` to `devDependencies`. These packages declare `os`/`cpu` constraints in their own `package.json`, npm silently skips mismatches in `optionalDependencies` but **fails hard** in `devDependencies` (e.g. `npm ci` on macOS ARM errors on `@oven/bun-linux-x64`).

## Approach

Instead of moving deps around, just remove them — they're not needed:

- **`@rollup/rollup-*`**: rollup already declares its own platform-specific `optionalDependencies`, npm resolves them transitively, the top-level entries are redundant
- **`@oven/bun-*`**: `setup-bun.mjs` (run by `prepare`) already gracefully handles missing binaries with a "install bun separately" fallback. Contributors who need bun can install it globally via [bun.sh](https://bun.sh)
- **Removed `postinstall`**: redundant with `prepare` (which already runs `setup-bun.mjs`), and the script isn't even shipped in the published package (`"files": ["dist"]`)

## Test plan

- [x] `npm ci` succeeds
- [x] `npm run build` succeeds
- [x] `npm pack` — published `package.json` contains no `optionalDependencies`