### PR TITLE
fix: remove duplicate --color-text-ghost from McpUiStyleVariableKey

### DIFF
--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -767,10 +767,6 @@
                       },
                       {
                         "type": "string",
-                        "const": "--color-text-ghost"
-                      },
-                      {
-                        "type": "string",
                         "const": "--color-border-primary"
                       },
                       {
@@ -1534,10 +1530,6 @@
                   },
                   {
                     "type": "string",
-                    "const": "--color-text-ghost"
-                  },
-                  {
-                    "type": "string",
                     "const": "--color-border-primary"
                   },
                   {
@@ -2136,10 +2128,6 @@
               {
                 "type": "string",
                 "const": "--color-text-disabled"
-              },
-              {
-                "type": "string",
-                "const": "--color-text-ghost"
               },
               {
                 "type": "string",
@@ -3109,10 +3097,6 @@
                       {
                         "type": "string",
                         "const": "--color-text-disabled"
-                      },
-                      {
-                        "type": "string",
-                        "const": "--color-text-ghost"
                       },
                       {
                         "type": "string",
@@ -4483,10 +4467,6 @@
         },
         {
           "type": "string",
-          "const": "--color-text-ghost"
-        },
-        {
-          "type": "string",
           "const": "--color-border-primary"
         },
         {
@@ -4796,10 +4776,6 @@
           {
             "type": "string",
             "const": "--color-text-disabled"
-          },
-          {
-            "type": "string",
-            "const": "--color-text-ghost"
           },
           {
             "type": "string",

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -51,7 +51,6 @@ export const McpUiStyleVariableKeySchema = z
     z.literal("--color-text-success"),
     z.literal("--color-text-warning"),
     z.literal("--color-text-disabled"),
-    z.literal("--color-text-ghost"),
     z.literal("--color-border-primary"),
     z.literal("--color-border-secondary"),
     z.literal("--color-border-tertiary"),

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -64,7 +64,6 @@ export type McpUiStyleVariableKey =
   | "--color-text-success"
   | "--color-text-warning"
   | "--color-text-disabled"
-  | "--color-text-ghost"
   // Border colors
   | "--color-border-primary"
   | "--color-border-secondary"


### PR DESCRIPTION
Removes the duplicate `--color-text-ghost` entry from the `McpUiStyleVariableKey` union type in `src/spec.types.ts` and regenerates the derived schema files.

## Motivation and Context
The `McpUiStyleVariableKey` type listed `--color-text-ghost` twice (lines 61 and 67). This is a copy-paste error — the stable spec (`specification/2026-01-26/apps.mdx`) only lists it once. The duplicate has no runtime impact but makes the type definition inconsistent with the spec.

## How Has This Been Tested?
- `npm test` — all 85 unit tests pass
- `npm run prettier` — all files pass formatting check
- `npm run generate:schemas` — schemas regenerated cleanly with no duplicate

## Breaking Changes
None. Removing a duplicate union member does not change the set of valid values.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
The duplicate was in the text colors section of `McpUiStyleVariableKey`. The fix removes line 67 (`| "--color-text-ghost"`) and runs `npm run generate:schemas` to update `src/generated/schema.ts`, `schema.test.ts`, and `schema.json`.