### PR TITLE
Fix autoResize reporting viewport height when content is taller than iframe

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1119,13 +1119,14 @@ export class App extends Protocol<AppRequest, AppNotification, AppResult> {
         scheduled = false;
         const html = document.documentElement;
 
-        // Measure actual content size by temporarily setting html to fit-content.
-        // This shrinks html to fit body (including body margins), giving us the
-        // true minimum size needed by the content.
+        // Measure actual content size by temporarily overriding html sizing.
+        // Width uses fit-content so content wraps at the host-provided width.
+        // Height uses max-content because fit-content would clamp to the viewport
+        // height when content is taller than the iframe, causing internal scrolling.
         const originalWidth = html.style.width;
         const originalHeight = html.style.height;
         html.style.width = "fit-content";
-        html.style.height = "fit-content";
+        html.style.height = "max-content";
         const rect = html.getBoundingClientRect();
         html.style.width = originalWidth;
         html.style.height = originalHeight;


### PR DESCRIPTION
## Problem

`setupSizeChangedNotifications` measures content by temporarily setting `html.style.height = "fit-content"`. But `fit-content` resolves to `min(max-content, max(min-content, stretch))`, and for `<html>` the `stretch` value is the iframe's viewport height.

- Content **shorter** than viewport → `fit-content` = content height ✓ (what #57 fixed)
- Content **taller** than viewport → `fit-content` = viewport height ✗

When content overflows the iframe, the SDK reports the (smaller) viewport height, the host never resizes the iframe, and users see a scrollbar inside the app.

## Fix

Use `max-content` for height — no available-space clamping, gives true intrinsic height in both shrink and grow cases. Width stays `fit-content` to preserve responsive wrapping at the host-provided width.