### PR TITLE
fix: make listServerResources() params optional

### DIFF
--- a/examples/video-resource-server/src/mcp-app.ts
+++ b/examples/video-resource-server/src/mcp-app.ts
@@ -123,7 +123,7 @@ async function discoverVideos() {
   }
 
   try {
-    const resourceList = await app.listServerResources({});
+    const resourceList = await app.listServerResources();
 
     const videoResources = resourceList.resources.filter((r) =>
       r.uri.startsWith("videos://"),

--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -794,7 +794,7 @@ describe("App <-> AppBridge integration", () => {
       await bridge.connect(bridgeTransport);
       await app.connect(appTransport);
 
-      const result = await app.listServerResources({});
+      const result = await app.listServerResources();
 
       expect(receivedRequests).toHaveLength(1);
       expect(result.resources).toEqual(resources);
@@ -826,7 +826,11 @@ describe("App <-> AppBridge integration", () => {
     it("onreadresource handles readServerResource() calls from App", async () => {
       const requestParams = { uri: "videos://bunny-1mb" };
       const contents = [
-        { uri: "videos://bunny-1mb", blob: "dmlkZW9kYXRh", mimeType: "video/mp4" },
+        {
+          uri: "videos://bunny-1mb",
+          blob: "dmlkZW9kYXRh",
+          mimeType: "video/mp4",
+        },
       ];
       const receivedRequests: unknown[] = [];
 

--- a/src/app.examples.ts
+++ b/src/app.examples.ts
@@ -335,7 +335,7 @@ async function App_listServerResources_buildPicker(
 ) {
   //#region App_listServerResources_buildPicker
   try {
-    const result = await app.listServerResources({});
+    const result = await app.listServerResources();
     const videoResources = result.resources.filter((r) =>
       r.mimeType?.startsWith("video/"),
     );

--- a/src/app.ts
+++ b/src/app.ts
@@ -805,7 +805,7 @@ export class App extends Protocol<AppRequest, AppNotification, AppResult> {
    *
    * Results may be paginated using the `cursor` parameter for servers with many resources.
    *
-   * @param params - Optional parameters (empty object `{}` for all resources, or `{ cursor }` for pagination)
+   * @param params - Optional parameters (omit for all resources, or `{ cursor }` for pagination)
    * @param options - Request options (timeout, etc.)
    * @returns List of resources with their URIs, names, descriptions, mimeTypes, and optional pagination cursor
    *
@@ -815,7 +815,7 @@ export class App extends Protocol<AppRequest, AppNotification, AppResult> {
    * @example Discover available videos and build a picker UI
    * ```ts source="./app.examples.ts#App_listServerResources_buildPicker"
    * try {
-   *   const result = await app.listServerResources({});
+   *   const result = await app.listServerResources();
    *   const videoResources = result.resources.filter((r) =>
    *     r.mimeType?.startsWith("video/"),
    *   );
@@ -833,7 +833,7 @@ export class App extends Protocol<AppRequest, AppNotification, AppResult> {
    * @see {@link readServerResource `readServerResource`} to read a specific resource
    */
   async listServerResources(
-    params: ListResourcesRequest["params"],
+    params?: ListResourcesRequest["params"],
     options?: RequestOptions,
   ): Promise<ListResourcesResult> {
     return await this.request(


### PR DESCRIPTION
Follow-up to #470.

Makes the `params` argument of `App.listServerResources()` optional, matching the MCP SDK's `Client.listResources(params?)` signature. No-arg calls now work for the common "list everything" case without requiring an empty `{}`.

Also includes a prettier reflow in `app-bridge.test.ts` that slipped through in #470.

cc @Avcharov