### PR TITLE
docs: ask contributors to allow maintainer edits on PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ We welcome contributions to the MCP Apps SDK! This document outlines the process
 - Update documentation as needed
 - Keep changes focused and atomic
 - Provide a clear description of changes
+- **Keep "Allow edits by maintainers" checked** when opening your PR — this lets maintainers rebase your branch and lets the [`/update-snapshots` workflow](#updating-snapshots-in-ci) push updated screenshots to it
 
 ## Running Examples
 


### PR DESCRIPTION
Adds a bullet to the PR guidelines in CONTRIBUTING.md asking contributors to keep **"Allow edits by maintainers"** checked.

## Why

- Lets maintainers rebase/update stale fork branches without asking
- Required for the `/update-snapshots` workflow to push updated golden screenshots to fork PRs