### PR TITLE
fix(ci): require maintainer association for /update-snapshots trigger

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -16,10 +16,14 @@ permissions:
 
 jobs:
   update-snapshots:
-    # Run on workflow_dispatch OR when someone comments "/update-snapshots" on a PR
+    # Run on workflow_dispatch OR when a maintainer comments "/update-snapshots" on a PR.
+    # author_association check prevents arbitrary commenters from triggering a job with
+    # contents:write that pushes a [skip ci] commit to the PR branch.
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.issue.pull_request && contains(github.event.comment.body, '/update-snapshots'))
+      (github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/update-snapshots') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     steps:
       - name: Get PR branch


### PR DESCRIPTION
## Problem

`.github/workflows/update-snapshots.yml` triggers on `issue_comment` whenever a PR comment contains `/update-snapshots`, with **no check on who posted the comment**.

### Attack vector

On a public repo, anyone who can comment on a PR can:
1. Comment `/update-snapshots` on any open PR
2. Trigger a job running with `permissions: contents: write`
3. That job checks out the PR head branch, runs `playwright test --update-snapshots`, and pushes a commit with `[skip ci]`

The `[skip ci]` tag means the pushed commit bypasses CI. Combined with PR approval rules that don't dismiss on new commits, this lets unreviewed pixel changes land.

## Fix

Add `github.event.comment.author_association` check to the job's existing `if:` condition. Only `OWNER`, `MEMBER`, or `COLLABORATOR` can trigger the comment path.

`workflow_dispatch` path is unchanged — it already requires repo write access to invoke.

## Diff

```yaml
if: >
  github.event_name == 'workflow_dispatch' ||
  (github.event.issue.pull_request &&
  contains(github.event.comment.body, '/update-snapshots') &&
  contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
```

Unauthorized comments now silently skip the job (no reaction, no comment — can add a deny-reaction job later if desired).