### PR TITLE
ci: use npm ci with caching, validate typedoc links, align Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
+          cache: npm
 
       - run: npm ci
 
@@ -71,11 +72,16 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
+          cache: npm
 
-      - run: npm install
+      - run: npm ci
 
       - run: npm run build
+
+      - name: Validate TypeDoc links
+        if: runner.os == 'Linux' && matrix.name == 'Linux x64'
+        run: npm exec typedoc -- --treatValidationWarningsAsErrors --emit none
 
       - run: npm run examples:build
 
@@ -111,7 +117,8 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
+          cache: npm
 
       - uses: astral-sh/setup-uv@v7
 
@@ -147,13 +154,13 @@ jobs:
         shell: wsl-bash {0}
         run: |
           sudo apt-get update
-          curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+          curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
           sudo apt-get install -y nodejs
 
       - name: Build and test in WSL
         shell: wsl-bash {0}
         run: |
-          npm install
+          npm ci
           npm run build
           npm run examples:build
           npm test
@@ -182,7 +189,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Create test project and install from git
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,8 +16,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
-      - run: npm install
+          node-version: "22"
+          cache: npm
+      - run: npm ci
       - run: npm run build
       - run: npm run docs
       - uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -59,7 +59,8 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
+          cache: npm
 
       - uses: astral-sh/setup-uv@v7
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "license": "MIT",
   "description": "MCP Apps SDK — Enable MCP servers to display interactive user interfaces in conversational clients.",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/src/app.js",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

Four CI hygiene fixes identified in a workflow audit.

## Changes

### 1. `npm install` → `npm ci`
`npm install` tolerates lockfile drift — a PR that works with drifted transitive deps can merge, then break for the next person running `npm ci`. Switched to `npm ci` which fails fast on mismatch.

- `ci.yml` build matrix (was line 76)
- `ci.yml` build-wsl (was line 156)
- `docs.yml` deploy job

(`npm-publish.yml` and `publish.yml` already used `npm ci`.)

### 2. npm dependency caching
Added `cache: npm` to `actions/setup-node` steps. Previously every CI job installed from cold. Now all jobs with a `package-lock.json` available get caching:

- `ci.yml`: prettier-fix, build, e2e
- `docs.yml`: deploy
- `update-snapshots.yml`: update-snapshots

Intentionally **not** added to:
- `ci.yml` test-git-install — no repo checkout, so no lockfile to hash (`cache: npm` would fail)
- `ci.yml` build-wsl — Node is installed manually inside WSL, no `setup-node` action to configure

### 3. TypeDoc link validation
CLAUDE.md documents `npm exec typedoc -- --treatValidationWarningsAsErrors --emit none` as the way to catch broken `{@link}` references, but it ran in **zero** CI workflows. A renamed export could break doc links and only surface at release time (`docs.yml` runs on release, not PR).

Added as a step in the build job after `npm run build`, gated to Linux x64 only (following the existing MCPB-pack pattern — doc validation is OS-agnostic).

**Verified locally: passes on current `main`** (exit 0, no broken links).

### 4. Node version alignment + `engines` field
Previously: CI validated on Node **20**, but `npm-publish.yml` published from Node **22**. A Node-22-only API in build tooling would pass publish but was never tested in CI.

- Aligned all workflows on **Node 22** (active LTS): `ci.yml` (5 places incl. WSL nodesource URL), `docs.yml`, `update-snapshots.yml`
- Added `"engines": { "node": ">=20" }` to `package.json` — floor matches `@types/node` 20.x and gives users on Node 18 a warning

## Validation

- [x] YAML syntax validated (`python3 yaml.safe_load` on all 5 workflow files)
- [x] `prettier --check` passes on all edited files
- [x] TypeDoc validation step runs clean on current main (exit 0)
- [x] `npm ci` already proven working in `npm-publish.yml` / `publish.yml` — lockfile is in sync

## Not changed

- `package-lock.json` — untouched
- `npm-publish.yml`, `publish.yml` — already had Node 22 + cache + npm ci