### PR TITLE
fix(deps): drop @hono/node-server override to patch GHSA-wc8c-qw6v-h7f6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1959,9 +1959,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.7",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
-      "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "seroval": "1.4.1",
     "seroval-plugins": "1.4.2",
     "solid-js": "1.9.10",
-    "@hono/node-server": "1.19.7",
     "@types/node": "20.19.27"
   }
 }


### PR DESCRIPTION
## Summary

Removes the `overrides` entry pinning `@hono/node-server` to `1.19.7`, which is vulnerable to [GHSA-wc8c-qw6v-h7f6](https://github.com/advisories/GHSA-wc8c-qw6v-h7f6) (HIGH — authorization bypass for protected static paths via encoded slashes in Serve Static middleware, fixed in 1.19.10).

## Why the override existed

Added in 71976101 as a workaround: `@modelcontextprotocol/sdk@1.25.3` required `@hono/node-server@^1.19.9`, which **did not yet exist** on the public npm registry at the time (latest was 1.19.7). The SDK was subsequently pinned to 1.25.2 (b9a459a6), but the override was kept as belt-and-braces.

## Why it's safe to remove now

- `@hono/node-server` 1.19.8–1.19.11 have since been published.
- The pinned SDK (1.25.2) requires `^1.19.7`, so natural resolution picks **1.19.11** (latest patch, includes the GHSA fix).
- No source code in this repo imports `@hono/node-server` directly — it's purely a transitive dep of the MCP SDK.
- All versions involved are in the 1.19.x patch range (no breaking changes per semver).

## Verification

```console
$ jq -r '.packages["node_modules/@hono/node-server"].version' package-lock.json
1.19.11

$ rg -c artifactory package-lock.json
(no matches)

$ npm audit | rg GHSA-wc8c
(no matches — resolved)
```

Lockfile regenerated with `--registry=https://registry.npmjs.org/` to avoid leaking internal registry URLs.