### PR TITLE
test: add unit tests for buildAllowAttribute

### DIFF
--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -16,6 +16,7 @@ import {
 import { App } from "./app";
 import {
   AppBridge,
+  buildAllowAttribute,
   getToolUiResourceUri,
   isToolVisibilityModelOnly,
   isToolVisibilityAppOnly,
@@ -1194,6 +1195,57 @@ describe("isToolVisibilityAppOnly", () => {
         _meta: { ui: { resourceUri: "ui://server/app.html" } },
       };
       expect(isToolVisibilityAppOnly(tool)).toBe(false);
+    });
+  });
+});
+
+describe("buildAllowAttribute", () => {
+  describe("returns empty string", () => {
+    it("when permissions is undefined", () => {
+      expect(buildAllowAttribute(undefined)).toBe("");
+    });
+
+    it("when permissions object is empty", () => {
+      expect(buildAllowAttribute({})).toBe("");
+    });
+  });
+
+  describe("returns a single permission directive", () => {
+    it("when only camera is set", () => {
+      expect(buildAllowAttribute({ camera: {} })).toBe("camera");
+    });
+
+    it("when only microphone is set", () => {
+      expect(buildAllowAttribute({ microphone: {} })).toBe("microphone");
+    });
+
+    it("when only geolocation is set", () => {
+      expect(buildAllowAttribute({ geolocation: {} })).toBe("geolocation");
+    });
+
+    it("when only clipboardWrite is set, maps to clipboard-write", () => {
+      expect(buildAllowAttribute({ clipboardWrite: {} })).toBe(
+        "clipboard-write",
+      );
+    });
+  });
+
+  describe("returns multiple directives joined with '; '", () => {
+    it("when camera and microphone are set", () => {
+      expect(buildAllowAttribute({ camera: {}, microphone: {} })).toBe(
+        "camera; microphone",
+      );
+    });
+
+    it("when all permissions are set", () => {
+      expect(
+        buildAllowAttribute({
+          camera: {},
+          microphone: {},
+          geolocation: {},
+          clipboardWrite: {},
+        }),
+      ).toBe("camera; microphone; geolocation; clipboard-write");
     });
   });
 });


### PR DESCRIPTION
Adds unit tests for the `buildAllowAttribute` utility function, which was the only exported utility in `app-bridge.ts` without test coverage.

## Motivation and Context
`buildAllowAttribute` maps `McpUiResourcePermissions` to an iframe `allow` attribute string (e.g. `{ clipboardWrite: {} }` → `"clipboard-write"`). It is exported and used in the host iframe setup, but had no tests. The adjacent utilities `isToolVisibilityModelOnly` and `isToolVisibilityAppOnly` both have full coverage - this brings `buildAllowAttribute` in line with that pattern.

## How Has This Been Tested?
- `npm test` — all 129 unit tests pass (8 new tests added).
- `npm run prettier` — all files pass formatting check.

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
