### PR TITLE
chore: bump ext-apps to 1.2.1

### DIFF
--- a/examples/basic-host/package.json
+++ b/examples/basic-host/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/basic-host",
   "name": "@modelcontextprotocol/ext-apps-basic-host",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && concurrently \"cross-env INPUT=index.html vite build\" \"cross-env INPUT=sandbox.html vite build\"",

--- a/examples/basic-server-preact/package.json
+++ b/examples/basic-server-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-preact",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Basic MCP App Server example using Preact",
   "repository": {

--- a/examples/basic-server-react/package.json
+++ b/examples/basic-server-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Basic MCP App Server example using React",
   "repository": {

--- a/examples/basic-server-solid/package.json
+++ b/examples/basic-server-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-solid",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Basic MCP App Server example using Solid",
   "repository": {

--- a/examples/basic-server-svelte/package.json
+++ b/examples/basic-server-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-svelte",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Basic MCP App Server example using Svelte",
   "repository": {

--- a/examples/basic-server-vanillajs/package.json
+++ b/examples/basic-server-vanillajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-vanillajs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Basic MCP App Server example using vanilla JavaScript",
   "repository": {

--- a/examples/basic-server-vue/package.json
+++ b/examples/basic-server-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-vue",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Basic MCP App Server example using Vue",
   "repository": {

--- a/examples/budget-allocator-server/package.json
+++ b/examples/budget-allocator-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-budget-allocator",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Budget allocator MCP App Server with interactive visualization",
   "repository": {

--- a/examples/cohort-heatmap-server/package.json
+++ b/examples/cohort-heatmap-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-cohort-heatmap",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Cohort heatmap MCP App Server for retention analysis",
   "repository": {

--- a/examples/customer-segmentation-server/package.json
+++ b/examples/customer-segmentation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-customer-segmentation",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Customer segmentation MCP App Server with filtering",
   "repository": {

--- a/examples/debug-server/package.json
+++ b/examples/debug-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-debug",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Debug MCP App Server for testing all SDK capabilities",
   "repository": {

--- a/examples/integration-server/package.json
+++ b/examples/integration-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/map-server/package.json
+++ b/examples/map-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-map",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "MCP App Server example with CesiumJS 3D globe and geocoding",
   "repository": {

--- a/examples/pdf-server/package.json
+++ b/examples/pdf-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-pdf",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "MCP server for loading and extracting text from PDF files with chunked pagination and interactive viewer",
   "repository": {

--- a/examples/qr-server/package.json
+++ b/examples/qr-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-qr",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "start": "uv run server.py",

--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/quickstart",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "private": true,
   "description": "Quickstart MCP App Server example",
@@ -22,9 +22,9 @@
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
-    "concurrently": "^9.2.1",
     "@types/express": "^5.0.0",
     "@types/node": "22.19.5",
+    "concurrently": "^9.2.1",
     "cross-env": "^10.1.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/examples/say-server/package.json
+++ b/examples/say-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-say",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Streaming TTS MCP App Server with karaoke-style text highlighting",
   "repository": {

--- a/examples/scenario-modeler-server/package.json
+++ b/examples/scenario-modeler-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-scenario-modeler",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Financial scenario modeling MCP App Server",
   "repository": {

--- a/examples/shadertoy-server/package.json
+++ b/examples/shadertoy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-shadertoy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "MCP App Server example for rendering ShaderToy-compatible GLSL shaders",
   "repository": {

--- a/examples/sheet-music-server/package.json
+++ b/examples/sheet-music-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-sheet-music",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "MCP App Server for rendering and playing sheet music from ABC notation",
   "repository": {

--- a/examples/system-monitor-server/package.json
+++ b/examples/system-monitor-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-system-monitor",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "System monitor MCP App Server with real-time stats",
   "repository": {

--- a/examples/threejs-server/package.json
+++ b/examples/threejs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-threejs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Three.js 3D visualization MCP App Server",
   "repository": {

--- a/examples/transcript-server/package.json
+++ b/examples/transcript-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-transcript",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "MCP App Server for live speech transcription",
   "repository": {

--- a/examples/video-resource-server/package.json
+++ b/examples/video-resource-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-video-resource",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "MCP App Server demonstrating video resources served as base64 blobs",
   "repository": {

--- a/examples/wiki-explorer-server/package.json
+++ b/examples/wiki-explorer-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-wiki-explorer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Wikipedia link explorer MCP App Server with graph visualization",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/ext-apps",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/ext-apps",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "workspaces": [
         "examples/*"
@@ -43,6 +43,9 @@
         "typescript": "^5.9.3",
         "zod": "^4.1.13"
       },
+      "engines": {
+        "node": ">=20"
+      },
       "peerDependencies": {
         "@modelcontextprotocol/sdk": "^1.24.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -60,7 +63,7 @@
     },
     "examples/basic-host": {
       "name": "@modelcontextprotocol/ext-apps-basic-host",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.24.0",
@@ -103,7 +106,7 @@
     },
     "examples/basic-server-preact": {
       "name": "@modelcontextprotocol/server-basic-preact",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -147,7 +150,7 @@
     },
     "examples/basic-server-react": {
       "name": "@modelcontextprotocol/server-basic-react",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -194,7 +197,7 @@
     },
     "examples/basic-server-solid": {
       "name": "@modelcontextprotocol/server-basic-solid",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -238,7 +241,7 @@
     },
     "examples/basic-server-svelte": {
       "name": "@modelcontextprotocol/server-basic-svelte",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -282,7 +285,7 @@
     },
     "examples/basic-server-vanillajs": {
       "name": "@modelcontextprotocol/server-basic-vanillajs",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -324,7 +327,7 @@
     },
     "examples/basic-server-vue": {
       "name": "@modelcontextprotocol/server-basic-vue",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -368,7 +371,7 @@
     },
     "examples/budget-allocator-server": {
       "name": "@modelcontextprotocol/server-budget-allocator",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -411,7 +414,7 @@
     },
     "examples/cohort-heatmap-server": {
       "name": "@modelcontextprotocol/server-cohort-heatmap",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -458,7 +461,7 @@
     },
     "examples/customer-segmentation-server": {
       "name": "@modelcontextprotocol/server-customer-segmentation",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -501,7 +504,7 @@
     },
     "examples/debug-server": {
       "name": "@modelcontextprotocol/server-debug",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -542,7 +545,7 @@
       "license": "MIT"
     },
     "examples/integration-server": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.24.0",
@@ -587,7 +590,7 @@
     },
     "examples/map-server": {
       "name": "@modelcontextprotocol/server-map",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -629,7 +632,7 @@
     },
     "examples/pdf-server": {
       "name": "@modelcontextprotocol/server-pdf",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -672,14 +675,14 @@
     },
     "examples/qr-server": {
       "name": "@modelcontextprotocol/server-qr",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0"
       }
     },
     "examples/quickstart": {
       "name": "@modelcontextprotocol/quickstart",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -711,7 +714,7 @@
     },
     "examples/say-server": {
       "name": "@modelcontextprotocol/server-say",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0"
@@ -719,7 +722,7 @@
     },
     "examples/scenario-modeler-server": {
       "name": "@modelcontextprotocol/server-scenario-modeler",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -767,7 +770,7 @@
     },
     "examples/shadertoy-server": {
       "name": "@modelcontextprotocol/server-shadertoy",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -809,7 +812,7 @@
     },
     "examples/sheet-music-server": {
       "name": "@modelcontextprotocol/server-sheet-music",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -852,7 +855,7 @@
     },
     "examples/system-monitor-server": {
       "name": "@modelcontextprotocol/server-system-monitor",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -896,7 +899,7 @@
     },
     "examples/threejs-server": {
       "name": "@modelcontextprotocol/server-threejs",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -945,7 +948,7 @@
     },
     "examples/transcript-server": {
       "name": "@modelcontextprotocol/server-transcript",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -988,7 +991,7 @@
     },
     "examples/video-resource-server": {
       "name": "@modelcontextprotocol/server-video-resource",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -1030,7 +1033,7 @@
     },
     "examples/wiki-explorer-server": {
       "name": "@modelcontextprotocol/server-wiki-explorer",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/modelcontextprotocol/ext-apps"
   },
   "homepage": "https://github.com/modelcontextprotocol/ext-apps",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "description": "MCP Apps SDK — Enable MCP servers to display interactive user interfaces in conversational clients.",
   "type": "module",
@@ -79,9 +79,10 @@
     "@modelcontextprotocol/sdk": "1.25.2",
     "@playwright/test": "1.57.0",
     "@types/bun": "^1.3.2",
+    "@types/node": "20.19.27",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
-    "@types/node": "20.19.27",
+    "bun": "^1.2.21",
     "caniuse-lite": "1.0.30001763",
     "cheerio": "1.1.2",
     "concurrently": "^9.2.1",
@@ -103,7 +104,6 @@
     "typedoc": "^0.28.14",
     "typedoc-github-theme": "^0.4.0",
     "typescript": "^5.9.3",
-    "bun": "^1.2.21",
     "zod": "^4.1.13"
   },
   "peerDependencies": {


### PR DESCRIPTION
Changes since 1.2.0:
- fix: bundle SDK+zod in react-with-deps (was byte-identical to ./react) (#539)
- fix(build): copy schema.json to dist and externalize zod (#534)
- fix: skip debug log for high-frequency tool-input-partial notifications (#546)
- fix(deps): drop @hono/node-server override to patch GHSA-wc8c-qw6v-h7f6 (#535)
- fix(readme): use picture element for theme-aware logo (#545)
- fix(ci): require maintainer association for /update-snapshots trigger (#532)
- fix: pre-commit stages only originally-staged files; add .npmrc (#538)
- ci: use npm ci with caching, validate typedoc links, align Node versions (#533)
- test: exclude screenshot-gen from default E2E run; wire pdf-server tests (#537)