### PR TITLE
feat(spec): add renderTiming to McpUiToolMeta for deferred View rendering

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -348,6 +348,12 @@ interface McpUiToolMeta {
    * - "app": Tool callable by the app from this server only
    */
   visibility?: Array<"model" | "app">;
+  /**
+   * When the host should render the View in the conversation. Default: "inline"
+   * - "inline": Render the View as soon as the tool returns
+   * - "end-of-turn": Defer rendering until the agent's turn is complete
+   */
+  renderTiming?: "inline" | "end-of-turn";
 }
 
 interface Tool {
@@ -418,6 +424,32 @@ Example (app-only tool, hidden from model):
 - **tools/list behavior:** Host MUST NOT include tools in the agent's tool list when their visibility does not include `"model"` (e.g., `visibility: ["app"]`)
 - **tools/call behavior:** Host MUST reject `tools/call` requests from apps for tools that don't include `"app"` in visibility
 - Cross-server tool calls are always blocked for app-only tools
+
+#### Render Timing:
+
+Some tools produce Views that should only be shown after the agent has finished its turn — for example, an "Apply to Site" action where the user should not interact with the View while the agent is still making additional tool calls. The `renderTiming` field controls this:
+
+- `renderTiming` defaults to `"inline"` if omitted
+- `"inline"`: Host SHOULD render the View as soon as the tool returns its result
+- `"end-of-turn"`: Host SHOULD defer rendering the View until the agent's turn is complete (no more tool calls or model output expected)
+- Host MAY ignore `renderTiming` and render immediately if it does not support deferred rendering
+- This field is orthogonal to `displayMode` (inline/fullscreen/pip), which controls the visual layout of the View
+
+Example (tool with deferred rendering):
+
+```json
+{
+  "name": "apply_changes",
+  "description": "Apply code changes to the user's site",
+  "inputSchema": { "type": "object" },
+  "_meta": {
+    "ui": {
+      "resourceUri": "ui://editor/apply-to-site",
+      "renderTiming": "end-of-turn"
+    }
+  }
+}
+```
 
 #### Benefits:
 
@@ -1753,6 +1785,24 @@ This proposal synthesizes feedback from the UI CWG and MCP-UI community, host im
 - **Two separate fields:** OpenAI uses `widgetAccessible` and `visibility` separately. Rejected as redundant; single `visibility` array covers all cases.
 - **Boolean `private` flag:** Simpler but less flexible; doesn't express model-only tools.
 - **Flat `ui/visibility` key:** Rejected in favor of nested structure for consistency with future `_meta.ui` fields.
+
+#### 6. Render Timing via Tool Metadata
+
+**Decision:** Use `_meta.ui.renderTiming` to let servers declare when a View should appear in the conversation.
+
+**Rationale:**
+
+- The server knows best whether its View requires user interaction during or after the agent's turn
+- Orthogonal to the visual `displayMode` (inline/fullscreen/pip) — timing and layout are independent concerns
+- Optional field with `"inline"` default preserves backward compatibility
+- Addresses a real production need: tools like "Apply to Site" should not show interactive UI while the agent is still making additional tool calls
+- Simple two-value enum (`"inline"` | `"end-of-turn"`) covers the observed use cases without over-engineering
+
+**Alternatives considered:**
+
+- **Host-side only:** Let hosts decide timing without server input. Rejected because the server has the domain knowledge about whether its View needs deferred rendering.
+- **Boolean `deferRendering` flag:** Simpler but less extensible if future timing modes are needed (e.g., `"on-user-action"`).
+- **Reuse `displayMode`:** Rejected because `displayMode` controls visual layout (inline/fullscreen/pip), not temporal presentation. Overloading it would create confusion.
 
 ### Backward Compatibility
 

--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -4013,6 +4013,20 @@
       },
       "additionalProperties": {}
     },
+    "McpUiRenderTiming": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "string",
+          "const": "inline"
+        },
+        {
+          "type": "string",
+          "const": "end-of-turn"
+        }
+      ],
+      "description": "When the host should render the View relative to the agent's turn."
+    },
     "McpUiRequestDisplayModeRequest": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -5251,6 +5265,19 @@
             ],
             "description": "Tool visibility scope - who can access the tool."
           }
+        },
+        "renderTiming": {
+          "description": "When the host should render the View in the conversation. Default: \"inline\"\n- \"inline\": Render the View as soon as the tool returns\n- \"end-of-turn\": Defer rendering until the agent's turn is complete (no more tool calls)",
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "inline"
+            },
+            {
+              "type": "string",
+              "const": "end-of-turn"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/src/generated/schema.test.ts
+++ b/src/generated/schema.test.ts
@@ -119,6 +119,10 @@ export type McpUiToolVisibilitySchemaInferredType = z.infer<
   typeof generated.McpUiToolVisibilitySchema
 >;
 
+export type McpUiRenderTimingSchemaInferredType = z.infer<
+  typeof generated.McpUiRenderTimingSchema
+>;
+
 export type McpUiToolMetaSchemaInferredType = z.infer<
   typeof generated.McpUiToolMetaSchema
 >;
@@ -293,6 +297,8 @@ expectType<spec.McpUiToolVisibility>(
 expectType<McpUiToolVisibilitySchemaInferredType>(
   {} as spec.McpUiToolVisibility,
 );
+expectType<spec.McpUiRenderTiming>({} as McpUiRenderTimingSchemaInferredType);
+expectType<McpUiRenderTimingSchemaInferredType>({} as spec.McpUiRenderTiming);
 expectType<spec.McpUiToolMeta>({} as McpUiToolMetaSchemaInferredType);
 expectType<McpUiToolMetaSchemaInferredType>({} as spec.McpUiToolMeta);
 expectType<spec.McpUiClientCapabilities>(

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -675,6 +675,15 @@ export const McpUiToolVisibilitySchema = z
   .describe("Tool visibility scope - who can access the tool.");
 
 /**
+ * @description When the host should render the View relative to the agent's turn.
+ */
+export const McpUiRenderTimingSchema = z
+  .union([z.literal("inline"), z.literal("end-of-turn")])
+  .describe(
+    "When the host should render the View relative to the agent's turn.",
+  );
+
+/**
  * @description UI-related metadata for tools.
  */
 export const McpUiToolMetaSchema = z.object({
@@ -699,6 +708,14 @@ export const McpUiToolMetaSchema = z.object({
     .describe(
       'Who can access this tool. Default: ["model", "app"]\n- "model": Tool visible to and callable by the agent\n- "app": Tool callable by the app from this server only',
     ),
+  /**
+   * @description When the host should render the View in the conversation. Default: "inline"
+   * - "inline": Render the View as soon as the tool returns
+   * - "end-of-turn": Defer rendering until the agent's turn is complete (no more tool calls)
+   */
+  renderTiming: McpUiRenderTimingSchema.optional().describe(
+    'When the host should render the View in the conversation. Default: "inline"\n- "inline": Render the View as soon as the tool returns\n- "end-of-turn": Defer rendering until the agent\'s turn is complete (no more tool calls)',
+  ),
 });
 
 /**

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -743,6 +743,11 @@ export interface McpUiRequestDisplayModeResult {
 export type McpUiToolVisibility = "model" | "app";
 
 /**
+ * @description When the host should render the View relative to the agent's turn.
+ */
+export type McpUiRenderTiming = "inline" | "end-of-turn";
+
+/**
  * @description UI-related metadata for tools.
  */
 export interface McpUiToolMeta {
@@ -762,6 +767,12 @@ export interface McpUiToolMeta {
    * - "app": Tool callable by the app from this server only
    */
   visibility?: McpUiToolVisibility[];
+  /**
+   * @description When the host should render the View in the conversation. Default: "inline"
+   * - "inline": Render the View as soon as the tool returns
+   * - "end-of-turn": Defer rendering until the agent's turn is complete (no more tool calls)
+   */
+  renderTiming?: McpUiRenderTiming;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export {
   type McpUiRequestDisplayModeRequest,
   type McpUiRequestDisplayModeResult,
   type McpUiToolVisibility,
+  type McpUiRenderTiming,
   type McpUiToolMeta,
   type McpUiClientCapabilities,
 } from "./spec.types.js";
@@ -129,6 +130,7 @@ export {
   McpUiRequestDisplayModeRequestSchema,
   McpUiRequestDisplayModeResultSchema,
   McpUiToolVisibilitySchema,
+  McpUiRenderTimingSchema,
   McpUiToolMetaSchema,
 } from "./generated/schema.js";
 


### PR DESCRIPTION
## Summary

Adds a new `renderTiming` field to `McpUiToolMeta` that lets servers declare **when** a View should appear in the conversation, addressing a gap in the spec where hosts have no standardized way to distinguish between Views that should render immediately vs. after the agent finishes its turn.

### Problem

The current spec defines `displayMode` (`inline` / `fullscreen` / `pip`) for **visual layout**, but has no concept of **temporal presentation** — i.e., _when_ to show the View. In agentic workflows where the LLM makes multiple sequential tool calls, some Views (e.g., "Apply to Site", confirmation dialogs) should only appear after the agent is done reasoning, to prevent premature user interaction.

Today, hosts that need this behavior must invent proprietary metadata fields. This PR standardizes the pattern.

### Solution

New type and field on `McpUiToolMeta`:

```typescript
type McpUiRenderTiming = "inline" | "end-of-turn";

interface McpUiToolMeta {
  resourceUri?: string;
  visibility?: McpUiToolVisibility[];
  renderTiming?: McpUiRenderTiming;  // NEW
}
```

- `"inline"` (default) — render the View as soon as the tool returns
- `"end-of-turn"` — defer rendering until the agent's turn is complete (no more tool calls)

### Design decisions

- **Server-declared hint**: The server has domain knowledge about whether its View needs deferred rendering; the host respects it but MAY ignore it
- **Orthogonal to `displayMode`**: Timing and layout are independent concerns — a View can be `end-of-turn` + `fullscreen`
- **Backward compatible**: Optional field, defaults to `"inline"`, existing tools are unaffected
- **Extensible**: String union allows future values (e.g., `"on-user-action"`) without breaking changes

### Prior art

- **Elementor's Angie** has shipped this pattern in production (as a vendor-specific `_meta.ui.displayMode` field with `"inline"` / `"end-of-turn"` values). This PR standardizes the concept.
- Related to the deferred `_meta["openai/toolInvocation/invoking"]` / `invoked` fields tracked in #201, though those are status text rather than timing control.

### Changes

- `src/spec.types.ts` — add `McpUiRenderTiming` type and `renderTiming` field to `McpUiToolMeta`
- `src/types.ts` — re-export new type and schema
- `specification/draft/apps.mdx` — document Render Timing section and design decision
- `src/generated/*` — auto-regenerated schemas (Zod + JSON Schema + tests)

## Test plan

- [x] `npm test` — all 121 tests pass
- [x] `npm run build` — builds successfully including all examples
- [x] Schema generation produces correct Zod and JSON Schema for the new type
- [x] Type-level integration tests verify `McpUiRenderTiming` round-trips correctly

Made with [Cursor](https://cursor.com)