### PR TITLE
test(e2e): fix pdf-server screenshot flake from random viewUUID

### DIFF
--- a/tests/e2e/servers.spec.ts
+++ b/tests/e2e/servers.spec.ts
@@ -51,6 +51,8 @@ const HOST_MASKS: Record<string, string[]> = {
   "basic-svelte": ['[class*="collapsiblePanel"]'],
   "basic-vanillajs": ['[class*="collapsiblePanel"]'],
   "basic-vue": ['[class*="collapsiblePanel"]'],
+  // PDF server result includes a random viewUUID in the preview text
+  "pdf-server": ['[class*="collapsiblePanel"]'],
   // System monitor has dynamic system stats in result
   "system-monitor": ['[class*="collapsiblePanel"]'],
 };


### PR DESCRIPTION
## Problem

The `e2e` job is failing on main since #506 merged.

**Root cause:** `display_pdf` now returns `"PDF opened. viewUUID: <random-uuid>..."` in its text content. The basic-host Tool Result panel shows the first 100 chars of the JSON-serialized result as a preview, which now includes the random UUID — so `pdf-server.png` can never match across runs.

Before #506 the result text was just `"Displaying PDF: <url>"` (the viewUUID lived only in `_meta`, past the 100-char preview cutoff).

## Fix

Add `pdf-server` to `HOST_MASKS` to mask the `collapsiblePanel` elements (Tool Input/Result). Same pattern used by `integration`, `basic-*`, and `system-monitor` servers that have dynamic result content.

## Next step

After this PR's CI runs, comment `/update-snapshots` to regenerate `pdf-server.png` — adding a mask changes the screenshot (masked regions render as pink boxes), plus #506 also changed the fullscreen button from `⛶` to an SVG icon.