### PR TITLE
Fix #501: Proposal: Direct AI processing channel (sendMessage immedia...

### DIFF
--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -587,6 +587,29 @@ describe("App <-> AppBridge integration", () => {
       expect(result.isError).toBe(true);
     });
 
+    it("app.sendMessage passes immediate flag to bridge.onmessage handler", async () => {
+      const receivedParams: unknown[] = [];
+      bridge.onmessage = async (params) => {
+        receivedParams.push(params);
+        return {};
+      };
+
+      await app.connect(appTransport);
+      const result = await app.sendMessage({
+        role: "user",
+        content: [{ type: "text", text: "Fix the syntax error automatically" }],
+        immediate: true,
+      });
+
+      expect(receivedParams).toHaveLength(1);
+      expect(receivedParams[0]).toMatchObject({
+        role: "user",
+        content: [{ type: "text", text: "Fix the syntax error automatically" }],
+        immediate: true,
+      });
+      expect(result).toEqual({});
+    });
+
     it("app.openLink triggers bridge.onopenlink and returns result", async () => {
       const receivedLinks: string[] = [];
       bridge.onopenlink = async (params) => {

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -771,6 +771,13 @@ export const McpUiMessageRequestSchema = z.object({
     content: z
       .array(ContentBlockSchema)
       .describe("Message content blocks (text, image, etc.)."),
+    /** @description If true, bypass the user input box and trigger AI processing directly. */
+    immediate: z
+      .boolean()
+      .optional()
+      .describe(
+        "If true, bypass the user input box and trigger AI processing directly.",
+      ),
   }),
 });
 

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -212,6 +212,13 @@ export interface McpUiMessageRequest {
     role: "user";
     /** @description Message content blocks (text, image, etc.). */
     content: ContentBlock[];
+    /**
+     * @description If true, the host should submit the message directly to the
+     * AI without placing it in the user's input box. The host may require
+     * capability negotiation before honouring this flag and may downgrade to
+     * the default input-box behaviour.
+     */
+    immediate?: boolean;
   };
 }
 


### PR DESCRIPTION
Closes #501

## Before

`app.sendMessage()` always routed messages through the host's user input box. An MCP App had no way to trigger AI processing directly — calling `sendMessage()` with an error message or proactive suggestion would deposit text into the input field and wait for the user to manually click Send, breaking any automated fix or suggestion loop.

`McpUiMessageRequest` in `src/spec.types.ts` and `McpUiMessageRequestSchema` in `src/generated/schema.ts` had no mechanism to express intent beyond placing a message in the input box.

## After

`McpUiMessageRequest` gains an optional `immediate` boolean field. When `immediate: true` is set, the host should submit the message directly to the AI, bypassing the input box entirely. The host retains full authority: it may require capability negotiation before honouring the flag and may silently downgrade to the default input-box behaviour if its policy requires it.

The field is additive and optional, so existing callers passing no `immediate` flag are unaffected.

## Changes

- **`src/spec.types.ts`** — Added `immediate?: boolean` to the inline message object type inside `McpUiMessageRequest`. JSDoc clarifies that hosts may require prior capability negotiation and may downgrade the flag.
- **`src/generated/schema.ts`** — Extended `McpUiMessageRequestSchema` with a matching `z.boolean().optional()` field named `immediate`, keeping the Zod schema in sync with the TypeScript interface.
- **`src/app-bridge.test.ts`** — Added a new test (`app.sendMessage passes immediate flag to bridge.onmessage handler`) that connects an app, calls `sendMessage()` with `immediate: true` in the message payload, and asserts that `bridge.onmessage` receives the flag verbatim and that the call resolves to the handler's return value.

## Testing

The new test in `src/app-bridge.test.ts` (line ~590) covers the round-trip path: the `immediate` flag set on the `sendMessage()` call appears unchanged in the params received by `bridge.onmessage`, and the resolved result matches the handler's return. All pre-existing `sendMessage` tests continue to pass without modification since the field is optional.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*