### PR TITLE
callServerTool: opt into progress-based timeout reset

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -860,7 +860,14 @@ export class App extends ProtocolWithEvents<
     return await this.request(
       { method: "tools/call", params },
       CallToolResultSchema,
-      options,
+      {
+        // Hosts may interpose long-running or user-interactive steps before the
+        // tool result arrives. Opting in here lets a host heartbeat keep the
+        // request alive past the default timeout; callers can still override.
+        onprogress: () => {},
+        resetTimeoutOnProgress: true,
+        ...options,
+      },
     );
   }
 


### PR DESCRIPTION
## Problem

A host may interpose a long-running or user-interactive step between the guest's `tools/call` and the server's response. During that wait, the base SDK's default request timeout in `Protocol.request()` fires and the guest surfaces `-32001 Request timed out`, even though the host is still working and will eventually deliver the result.

## Change

`callServerTool` now defaults `onprogress` to a no-op and `resetTimeoutOnProgress` to `true`. This causes `Protocol.request` to:
- include `_meta.progressToken` in the outgoing request
- reset the per-request timer when a `notifications/progress` arrives for that token

Hosts can then heartbeat (`notifications/progress`) during long-running interposed steps to keep the request alive. Tool calls are the request type expected to be long-running, so this is the right layer to opt in. Callers can still override both options.

No behavior change for hosts that don't send progress — the no-op handler just makes the SDK *able* to receive heartbeats.