### PR TITLE
fix: migrate to nested _meta.ui.resourceUri format

### DIFF
--- a/examples/map-server/server.ts
+++ b/examples/map-server/server.ts
@@ -18,7 +18,6 @@ import {
   registerAppTool,
   registerAppResource,
   RESOURCE_MIME_TYPE,
-  RESOURCE_URI_META_KEY,
 } from "@modelcontextprotocol/ext-apps/server";
 import { startServer } from "./server-utils.js";
 
@@ -173,7 +172,7 @@ export function createServer(): McpServer {
           .optional()
           .describe("Optional label to display on the map"),
       },
-      _meta: { [RESOURCE_URI_META_KEY]: RESOURCE_URI },
+      _meta: { ui: { resourceUri: RESOURCE_URI } },
     },
     async ({ west, south, east, north, label }): Promise<CallToolResult> => ({
       content: [

--- a/examples/qr-server/server.py
+++ b/examples/qr-server/server.py
@@ -20,7 +20,7 @@ PORT = int(os.environ.get("PORT", "3108"))
 mcp = FastMCP("QR Server", port=PORT, stateless_http=True)
 
 
-@mcp.tool(meta={"ui/resourceUri": WIDGET_URI})
+@mcp.tool(meta={"ui": {"resourceUri": WIDGET_URI}})
 def generate_qr(
     text: str,
     box_size: int = 10,

--- a/examples/transcript-server/server.ts
+++ b/examples/transcript-server/server.ts
@@ -10,7 +10,6 @@ import {
   registerAppTool,
   registerAppResource,
   RESOURCE_MIME_TYPE,
-  RESOURCE_URI_META_KEY,
 } from "@modelcontextprotocol/ext-apps/server";
 import { startServer } from "./server-utils.js";
 
@@ -35,7 +34,7 @@ export function createServer(): McpServer {
       description:
         "Opens a live speech transcription interface using the Web Speech API.",
       inputSchema: {},
-      _meta: { [RESOURCE_URI_META_KEY]: RESOURCE_URI },
+      _meta: { ui: { resourceUri: RESOURCE_URI } },
     },
     async (): Promise<CallToolResult> => {
       return {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -94,7 +94,7 @@ export interface McpUiAppResourceConfig extends ResourceMetadata {
  *   description: "Get current weather for a location",
  *   inputSchema: { location: z.string() },
  *   _meta: {
- *     [RESOURCE_URI_META_KEY]: "ui://weather/widget.html",
+ *     ui: { resourceUri: "ui://weather/widget.html" },
  *   },
  * }, async (args) => {
  *   const weather = await fetchWeather(args.location);


### PR DESCRIPTION
## Summary
- Migrate remaining examples (`qr-server`, `transcript-server`, `map-server`) from the deprecated flat `_meta["ui/resourceUri"]` format to the newer nested `_meta.ui.resourceUri` format
- Update `registerAppTool` JSDoc example in `src/server/index.ts` to show the new format
- Remove unused `RESOURCE_URI_META_KEY` imports from migrated examples

This ensures mobile client compatibility, which only supports the nested meta schema URI format.

## Test plan
- [ ] Verify examples still render correctly in the basic-host
- [ ] Confirm `npm run build:all` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)