### PR TITLE
test(e2e): poll for initial shrink-to-fit zoom before asserting

### DIFF
--- a/tests/e2e/pdf-viewer-zoom.spec.ts
+++ b/tests/e2e/pdf-viewer-zoom.spec.ts
@@ -63,8 +63,13 @@ test.describe("PDF Viewer — fullscreen fit + pinch zoom", () => {
     await waitForPdfRender(page);
     const app = getAppFrame(page);
 
+    // Initial fit-to-width measures container.clientWidth immediately after
+    // showViewer() flips display:flex; under CI load the reflow can lag, so
+    // poll until the shrink-to-fit scale has actually applied.
+    await expect
+      .poll(() => readZoomPercent(page), { timeout: 5000 })
+      .toBeLessThan(100);
     const inlineZoom = await readZoomPercent(page);
-    expect(inlineZoom).toBeLessThan(100);
 
     // Widen + give plenty of height, then enter fullscreen. Fullscreen uses
     // fit-to-PAGE (whole page visible), so the resulting zoom is whichever


### PR DESCRIPTION
Deflakes `pdf-viewer-zoom.spec.ts:67` — ~6 failures in the 30 runs since #583.

The initial fit-to-width measures `container.clientWidth` immediately after `showViewer()` flips `display:flex`. Under CI load the reflow can lag a tick, leaving `widthFit >= 1.0` and zoom at 100% when first read, which intermittently fails the `toBeLessThan(100)` assertion.

Swap the single-shot read for `expect.poll`, matching the pattern already used for the post-fullscreen assertion a few lines below, then capture `inlineZoom` for the subsequent comparison.