### PR TITLE
chore: bump ext-apps to 1.6.0

### DIFF
--- a/examples/basic-host/package.json
+++ b/examples/basic-host/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/basic-host",
   "name": "@modelcontextprotocol/ext-apps-basic-host",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && concurrently \"cross-env INPUT=index.html vite build\" \"cross-env INPUT=sandbox.html vite build\"",

--- a/examples/basic-server-preact/package.json
+++ b/examples/basic-server-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-preact",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Basic MCP App Server example using Preact",
   "repository": {

--- a/examples/basic-server-react/package.json
+++ b/examples/basic-server-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-react",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Basic MCP App Server example using React",
   "repository": {

--- a/examples/basic-server-solid/package.json
+++ b/examples/basic-server-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-solid",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Basic MCP App Server example using Solid",
   "repository": {

--- a/examples/basic-server-svelte/package.json
+++ b/examples/basic-server-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-svelte",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Basic MCP App Server example using Svelte",
   "repository": {

--- a/examples/basic-server-vanillajs/package.json
+++ b/examples/basic-server-vanillajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-vanillajs",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Basic MCP App Server example using vanilla JavaScript",
   "repository": {

--- a/examples/basic-server-vue/package.json
+++ b/examples/basic-server-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-vue",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Basic MCP App Server example using Vue",
   "repository": {

--- a/examples/budget-allocator-server/package.json
+++ b/examples/budget-allocator-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-budget-allocator",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Budget allocator MCP App Server with interactive visualization",
   "repository": {

--- a/examples/cohort-heatmap-server/package.json
+++ b/examples/cohort-heatmap-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-cohort-heatmap",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Cohort heatmap MCP App Server for retention analysis",
   "repository": {

--- a/examples/customer-segmentation-server/package.json
+++ b/examples/customer-segmentation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-customer-segmentation",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Customer segmentation MCP App Server with filtering",
   "repository": {

--- a/examples/debug-server/package.json
+++ b/examples/debug-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-debug",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Debug MCP App Server for testing all SDK capabilities",
   "repository": {

--- a/examples/integration-server/package.json
+++ b/examples/integration-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-server",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/map-server/package.json
+++ b/examples/map-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-map",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "MCP App Server example with CesiumJS 3D globe and geocoding",
   "repository": {

--- a/examples/pdf-server/package.json
+++ b/examples/pdf-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-pdf",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "MCP server for loading and extracting text from PDF files with chunked pagination and interactive viewer",
   "repository": {

--- a/examples/qr-server/package.json
+++ b/examples/qr-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-qr",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "start": "uv run server.py",

--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/quickstart",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "private": true,
   "description": "Quickstart MCP App Server example",

--- a/examples/say-server/package.json
+++ b/examples/say-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-say",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "Streaming TTS MCP App Server with karaoke-style text highlighting",
   "repository": {

--- a/examples/scenario-modeler-server/package.json
+++ b/examples/scenario-modeler-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-scenario-modeler",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Financial scenario modeling MCP App Server",
   "repository": {

--- a/examples/shadertoy-server/package.json
+++ b/examples/shadertoy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-shadertoy",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "MCP App Server example for rendering ShaderToy-compatible GLSL shaders",
   "repository": {

--- a/examples/sheet-music-server/package.json
+++ b/examples/sheet-music-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-sheet-music",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "MCP App Server for rendering and playing sheet music from ABC notation",
   "repository": {

--- a/examples/system-monitor-server/package.json
+++ b/examples/system-monitor-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-system-monitor",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "System monitor MCP App Server with real-time stats",
   "repository": {

--- a/examples/threejs-server/package.json
+++ b/examples/threejs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-threejs",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Three.js 3D visualization MCP App Server",
   "repository": {

--- a/examples/transcript-server/package.json
+++ b/examples/transcript-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-transcript",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "MCP App Server for live speech transcription",
   "repository": {

--- a/examples/video-resource-server/package.json
+++ b/examples/video-resource-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-video-resource",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "MCP App Server demonstrating video resources served as base64 blobs",
   "repository": {

--- a/examples/wiki-explorer-server/package.json
+++ b/examples/wiki-explorer-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-wiki-explorer",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Wikipedia link explorer MCP App Server with graph visualization",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/ext-apps",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/ext-apps",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "workspaces": [
         "examples/*"
@@ -63,7 +63,7 @@
     },
     "examples/basic-host": {
       "name": "@modelcontextprotocol/ext-apps-basic-host",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -106,7 +106,7 @@
     },
     "examples/basic-server-preact": {
       "name": "@modelcontextprotocol/server-basic-preact",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -150,7 +150,7 @@
     },
     "examples/basic-server-react": {
       "name": "@modelcontextprotocol/server-basic-react",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -197,7 +197,7 @@
     },
     "examples/basic-server-solid": {
       "name": "@modelcontextprotocol/server-basic-solid",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -241,7 +241,7 @@
     },
     "examples/basic-server-svelte": {
       "name": "@modelcontextprotocol/server-basic-svelte",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -285,7 +285,7 @@
     },
     "examples/basic-server-vanillajs": {
       "name": "@modelcontextprotocol/server-basic-vanillajs",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -327,7 +327,7 @@
     },
     "examples/basic-server-vue": {
       "name": "@modelcontextprotocol/server-basic-vue",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -371,7 +371,7 @@
     },
     "examples/budget-allocator-server": {
       "name": "@modelcontextprotocol/server-budget-allocator",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -414,7 +414,7 @@
     },
     "examples/cohort-heatmap-server": {
       "name": "@modelcontextprotocol/server-cohort-heatmap",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -461,7 +461,7 @@
     },
     "examples/customer-segmentation-server": {
       "name": "@modelcontextprotocol/server-customer-segmentation",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -504,7 +504,7 @@
     },
     "examples/debug-server": {
       "name": "@modelcontextprotocol/server-debug",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -545,7 +545,7 @@
       "license": "MIT"
     },
     "examples/integration-server": {
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -590,7 +590,7 @@
     },
     "examples/map-server": {
       "name": "@modelcontextprotocol/server-map",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -632,7 +632,7 @@
     },
     "examples/pdf-server": {
       "name": "@modelcontextprotocol/server-pdf",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -676,7 +676,7 @@
     },
     "examples/qr-server": {
       "name": "@modelcontextprotocol/server-qr",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0"
@@ -684,7 +684,7 @@
     },
     "examples/quickstart": {
       "name": "@modelcontextprotocol/quickstart",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -716,7 +716,7 @@
     },
     "examples/say-server": {
       "name": "@modelcontextprotocol/server-say",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -725,7 +725,7 @@
     },
     "examples/scenario-modeler-server": {
       "name": "@modelcontextprotocol/server-scenario-modeler",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -773,7 +773,7 @@
     },
     "examples/shadertoy-server": {
       "name": "@modelcontextprotocol/server-shadertoy",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -815,7 +815,7 @@
     },
     "examples/sheet-music-server": {
       "name": "@modelcontextprotocol/server-sheet-music",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -858,7 +858,7 @@
     },
     "examples/system-monitor-server": {
       "name": "@modelcontextprotocol/server-system-monitor",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -928,7 +928,7 @@
     },
     "examples/threejs-server": {
       "name": "@modelcontextprotocol/server-threejs",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -977,7 +977,7 @@
     },
     "examples/transcript-server": {
       "name": "@modelcontextprotocol/server-transcript",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -1020,7 +1020,7 @@
     },
     "examples/video-resource-server": {
       "name": "@modelcontextprotocol/server-video-resource",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
@@ -1062,7 +1062,7 @@
     },
     "examples/wiki-explorer-server": {
       "name": "@modelcontextprotocol/server-wiki-explorer",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/modelcontextprotocol/ext-apps"
   },
   "homepage": "https://github.com/modelcontextprotocol/ext-apps",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "description": "MCP Apps SDK — Enable MCP servers to display interactive user interfaces in conversational clients.",
   "type": "module",


### PR DESCRIPTION
## Summary

Bumps `@modelcontextprotocol/ext-apps` and all example workspaces from 1.5.0 → 1.6.0.

## Changes since 1.5.0

- `App.callServerTool()` now opts into progress-based timeout reset by default (#600) — outgoing `tools/call` carries `_meta.progressToken` and `notifications/progress` from the host resets the per-request timer, so hosts can heartbeat during long-running/user-interactive steps without the guest seeing a spurious `-32001` timeout. Callers can still override.
- e2e: poll for initial shrink-to-fit zoom before asserting (#607) — test-only flake fix.

## Test Plan

- `npm run check:versions` passes
- Pre-commit hook ran `npm run build:all` successfully