### PR TITLE
feat: port to SDK v2 via concrete Protocol (typescript-sdk#1891)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "author": "Olivier Chafik",
   "devDependencies": {
     "@boneskull/typedoc-plugin-mermaid": "^0.2.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^2.0.0-alpha.2",
     "@playwright/test": "1.57.0",
     "@types/bun": "^1.3.2",
     "@types/node": "20.19.27",
@@ -107,7 +107,7 @@
     "zod": "^4.1.13"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^2.0.0-alpha.2",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "zod": "^3.25.0 || ^4.0.0"

--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -1325,7 +1325,7 @@ export class AppBridge extends ProtocolWithEvents<
    * Verify that the guest supports the capability required for the given request method.
    * @internal
    */
-  assertCapabilityForMethod(method: AppRequest["method"]): void {
+  assertCapabilityForMethod(method: string): void {
     // TODO
   }
 
@@ -1341,7 +1341,7 @@ export class AppBridge extends ProtocolWithEvents<
    * Verify that the host supports the capability required for the given notification method.
    * @internal
    */
-  assertNotificationCapability(method: AppNotification["method"]): void {
+  assertNotificationCapability(method: string): void {
     // TODO
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -762,7 +762,7 @@ export class App extends ProtocolWithEvents<
    * Verify that the host supports the capability required for the given request method.
    * @internal
    */
-  assertCapabilityForMethod(method: AppRequest["method"]): void {
+  assertCapabilityForMethod(method: string): void {
     // TODO
   }
 
@@ -792,7 +792,7 @@ export class App extends ProtocolWithEvents<
    * Verify that the app supports the capability required for the given notification method.
    * @internal
    */
-  assertNotificationCapability(method: AppNotification["method"]): void {
+  assertNotificationCapability(method: string): void {
     // TODO
   }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -5,12 +5,10 @@ import {
   Result,
   type BaseContext,
   type LegacyContextFields,
+  type ZodLikeRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
 type AppContext = BaseContext & LegacyContextFields;
-import { ZodLiteral, ZodObject } from "zod/v4";
-
-type MethodSchema = ZodObject<{ method: ZodLiteral<string> }>;
 
 /**
  * Per-event state: a singular `on*` handler (replace semantics) plus a
@@ -78,7 +76,7 @@ export abstract class ProtocolWithEvents<
    * schema on first use.
    */
   protected abstract readonly eventSchemas: {
-    [K in keyof EventMap]: MethodSchema;
+    [K in keyof EventMap]: ZodLikeRequestSchema;
   };
 
   /**
@@ -202,12 +200,15 @@ export abstract class ProtocolWithEvents<
 
   // ── Handler registration with double-set protection ─────────────────
 
-  // The two overrides below are arrow-function class fields rather than
-  // prototype methods so that Protocol's constructor — which registers its
-  // own ping/cancelled/progress handlers via `this.setRequestHandler`
-  // before our fields initialize — hits the base implementation and skips
-  // tracking. Converting these to proper methods would crash with
-  // `_registeredMethods` undefined during super().
+  // These overrides are prototype methods, so Protocol's constructor (which
+  // registers built-in ping/cancelled/progress handlers via
+  // `this.setRequestHandler` during super()) dispatches here before our own
+  // fields have initialized. The `_registeredMethods === undefined` guard
+  // skips tracking during that window.
+  //
+  // The base method has four overloads in v2; we expose only the Zod-schema
+  // form here since that is all this package uses. Subclasses retain the
+  // typed (request, ctx) handler signature.
 
   /**
    * Registers a request handler. Throws if a handler for the same method
@@ -216,11 +217,24 @@ export abstract class ProtocolWithEvents<
    *
    * @throws {Error} if a handler for this method is already registered.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  override setRequestHandler = ((...args: any) => {
-    this._assertMethodNotRegistered(args[0], "setRequestHandler");
-    super.setRequestHandler(...(args as [MethodSchema, () => Result]));
-  }) as Protocol<AppContext>["setRequestHandler"];
+  override setRequestHandler<T extends ZodLikeRequestSchema>(
+    requestSchema: T,
+    handler: (
+      request: ReturnType<T["parse"]>,
+      ctx: AppContext,
+    ) => Result | Promise<Result>,
+  ): void;
+  override setRequestHandler(
+    schema: ZodLikeRequestSchema,
+    handler: (request: unknown, ctx: AppContext) => Result | Promise<Result>,
+  ): void {
+    if (this._registeredMethods === undefined) {
+      super.setRequestHandler(schema, handler);
+      return;
+    }
+    this._assertMethodNotRegistered(schema, "setRequestHandler");
+    super.setRequestHandler(schema, handler);
+  }
 
   /**
    * Registers a notification handler. Throws if a handler for the same
@@ -229,11 +243,21 @@ export abstract class ProtocolWithEvents<
    *
    * @throws {Error} if a handler for this method is already registered.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  override setNotificationHandler = ((...args: any) => {
-    this._assertMethodNotRegistered(args[0], "setNotificationHandler");
-    super.setNotificationHandler(...(args as [MethodSchema, () => void]));
-  }) as Protocol<AppContext>["setNotificationHandler"];
+  override setNotificationHandler<T extends ZodLikeRequestSchema>(
+    notificationSchema: T,
+    handler: (notification: ReturnType<T["parse"]>) => void | Promise<void>,
+  ): void;
+  override setNotificationHandler(
+    schema: ZodLikeRequestSchema,
+    handler: (notification: unknown) => void | Promise<void>,
+  ): void {
+    if (this._registeredMethods === undefined) {
+      super.setNotificationHandler(schema, handler);
+      return;
+    }
+    this._assertMethodNotRegistered(schema, "setNotificationHandler");
+    super.setNotificationHandler(schema, handler);
+  }
 
   /**
    * Warn if a request handler `on*` setter is replacing a previously-set
@@ -256,15 +280,30 @@ export abstract class ProtocolWithEvents<
    * Replace a request handler, bypassing double-set protection. Used by
    * `on*` request-handler setters that need replace semantics.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  protected replaceRequestHandler = ((...args: any) => {
-    const method = (args[0] as MethodSchema).shape.method.value;
-    this._registeredMethods.add(method);
-    super.setRequestHandler(...(args as [MethodSchema, () => Result]));
-  }) as Protocol<AppContext>["setRequestHandler"];
+  protected replaceRequestHandler<T extends ZodLikeRequestSchema>(
+    requestSchema: T,
+    handler: (
+      request: ReturnType<T["parse"]>,
+      ctx: AppContext,
+    ) => Result | Promise<Result>,
+  ): void;
+  protected replaceRequestHandler(
+    schema: ZodLikeRequestSchema,
+    handler: (request: unknown, ctx: AppContext) => Result | Promise<Result>,
+  ): void {
+    this._registeredMethods.add(this._methodOf(schema));
+    super.setRequestHandler(schema, handler);
+  }
 
-  private _assertMethodNotRegistered(schema: unknown, via: string): void {
-    const method = (schema as MethodSchema).shape.method.value;
+  private _methodOf(arg: ZodLikeRequestSchema | string): string {
+    return typeof arg === "string" ? arg : arg.shape.method.value;
+  }
+
+  private _assertMethodNotRegistered(
+    schema: ZodLikeRequestSchema | string,
+    via: string,
+  ): void {
+    const method = this._methodOf(schema);
     if (this._registeredMethods.has(method)) {
       throw new Error(
         `Handler for "${method}" already registered (via ${via}). ` +

--- a/src/events.ts
+++ b/src/events.ts
@@ -3,7 +3,11 @@ import {
   Request,
   Notification,
   Result,
+  type BaseContext,
+  type LegacyContextFields,
 } from "@modelcontextprotocol/sdk/types.js";
+
+type AppContext = BaseContext & LegacyContextFields;
 import { ZodLiteral, ZodObject } from "zod/v4";
 
 type MethodSchema = ZodObject<{ method: ZodLiteral<string> }>;
@@ -61,7 +65,10 @@ export abstract class ProtocolWithEvents<
   SendNotificationT extends Notification,
   SendResultT extends Result,
   EventMap extends Record<string, unknown>,
-> extends Protocol<SendRequestT, SendNotificationT, SendResultT> {
+> extends Protocol<AppContext> {
+  protected buildContext(ctx: AppContext): AppContext {
+    return ctx;
+  }
   private _registeredMethods = new Set<string>();
   private _eventSlots = new Map<keyof EventMap, EventSlot>();
 
@@ -209,14 +216,11 @@ export abstract class ProtocolWithEvents<
    *
    * @throws {Error} if a handler for this method is already registered.
    */
-  override setRequestHandler: Protocol<
-    SendRequestT,
-    SendNotificationT,
-    SendResultT
-  >["setRequestHandler"] = (schema, handler) => {
-    this._assertMethodNotRegistered(schema, "setRequestHandler");
-    super.setRequestHandler(schema, handler);
-  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  override setRequestHandler = ((...args: any) => {
+    this._assertMethodNotRegistered(args[0], "setRequestHandler");
+    super.setRequestHandler(...(args as [MethodSchema, () => Result]));
+  }) as Protocol<AppContext>["setRequestHandler"];
 
   /**
    * Registers a notification handler. Throws if a handler for the same
@@ -225,14 +229,11 @@ export abstract class ProtocolWithEvents<
    *
    * @throws {Error} if a handler for this method is already registered.
    */
-  override setNotificationHandler: Protocol<
-    SendRequestT,
-    SendNotificationT,
-    SendResultT
-  >["setNotificationHandler"] = (schema, handler) => {
-    this._assertMethodNotRegistered(schema, "setNotificationHandler");
-    super.setNotificationHandler(schema, handler);
-  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  override setNotificationHandler = ((...args: any) => {
+    this._assertMethodNotRegistered(args[0], "setNotificationHandler");
+    super.setNotificationHandler(...(args as [MethodSchema, () => void]));
+  }) as Protocol<AppContext>["setNotificationHandler"];
 
   /**
    * Warn if a request handler `on*` setter is replacing a previously-set
@@ -255,15 +256,12 @@ export abstract class ProtocolWithEvents<
    * Replace a request handler, bypassing double-set protection. Used by
    * `on*` request-handler setters that need replace semantics.
    */
-  protected replaceRequestHandler: Protocol<
-    SendRequestT,
-    SendNotificationT,
-    SendResultT
-  >["setRequestHandler"] = (schema, handler) => {
-    const method = (schema as MethodSchema).shape.method.value;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected replaceRequestHandler = ((...args: any) => {
+    const method = (args[0] as MethodSchema).shape.method.value;
     this._registeredMethods.add(method);
-    super.setRequestHandler(schema, handler);
-  };
+    super.setRequestHandler(...(args as [MethodSchema, () => Result]));
+  }) as Protocol<AppContext>["setRequestHandler"];
 
   private _assertMethodNotRegistered(schema: unknown, via: string): void {
     const method = (schema as MethodSchema).shape.method.value;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -45,7 +45,7 @@ import type {
   McpServer,
   RegisteredTool,
   ResourceMetadata,
-  ToolCallback as SchemaToolCallback,
+  ToolCallback,
   ReadResourceCallback as _ReadResourceCallback,
   RegisteredResource,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -55,13 +55,6 @@ import type {
   StandardSchemaWithJSON,
 } from "@modelcontextprotocol/sdk/server/zod-compat.js";
 import type { ZodRawShape } from "@modelcontextprotocol/sdk";
-
-type ToolCallback<Args extends ZodRawShapeCompat | AnySchema | undefined> =
-  Args extends ZodRawShape
-    ? LegacyToolCallback<Args>
-    : Args extends StandardSchemaWithJSON
-      ? SchemaToolCallback<Args>
-      : SchemaToolCallback<undefined>;
 import type {
   ClientCapabilities,
   ReadResourceResult,
@@ -70,7 +63,7 @@ import type {
 
 // Re-exports for convenience
 export { RESOURCE_URI_META_KEY, RESOURCE_MIME_TYPE };
-export type { ResourceMetadata, ToolCallback };
+export type { ResourceMetadata, ToolCallback, LegacyToolCallback };
 
 /**
  * Base tool configuration matching the standard MCP server tool options.
@@ -224,8 +217,8 @@ export interface McpUiAppResourceConfig extends ResourceMetadata {
  * @see {@link registerAppResource `registerAppResource`} to register the HTML resource referenced by the tool
  */
 export function registerAppTool<
-  OutputArgs extends ZodRawShapeCompat | AnySchema,
-  InputArgs extends undefined | ZodRawShapeCompat | AnySchema = undefined,
+  OutputArgs extends StandardSchemaWithJSON,
+  InputArgs extends StandardSchemaWithJSON | undefined = undefined,
 >(
   server: Pick<McpServer, "registerTool">,
   name: string,
@@ -234,6 +227,25 @@ export function registerAppTool<
     outputSchema?: OutputArgs;
   },
   cb: ToolCallback<InputArgs>,
+): RegisteredTool;
+/** Raw-shape form: `inputSchema` may be a plain `{ field: z.string() }` record. */
+export function registerAppTool<
+  InputArgs extends ZodRawShape,
+  OutputArgs extends ZodRawShape | StandardSchemaWithJSON | undefined = undefined,
+>(
+  server: Pick<McpServer, "registerTool">,
+  name: string,
+  config: McpUiAppToolConfig & {
+    inputSchema: InputArgs;
+    outputSchema?: OutputArgs;
+  },
+  cb: LegacyToolCallback<InputArgs>,
+): RegisteredTool;
+export function registerAppTool(
+  server: Pick<McpServer, "registerTool">,
+  name: string,
+  config: McpUiAppToolConfig,
+  cb: (...args: never) => ReturnType<ToolCallback<undefined>>,
 ): RegisteredTool {
   // Normalize metadata for backward compatibility:
   // - If _meta.ui.resourceUri is set, also set the legacy flat key
@@ -251,12 +263,11 @@ export function registerAppTool<
     normalizedMeta = { ...meta, ui: { ...uiMeta, resourceUri: legacyUri } };
   }
 
-  return (server.registerTool as McpServer["registerTool"])(
-    name,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    { ...config, _meta: normalizedMeta } as any,
-    cb as SchemaToolCallback<undefined>,
-  );
+  // The two public overloads above guarantee (config.inputSchema, cb) match one
+  // of registerTool's overloads. The impl signature loses that pairing, so this
+  // forward needs a single suppression rather than three casts.
+  // @ts-expect-error -- forwarding overload-paired args through one impl signature
+  return server.registerTool(name, { ...config, _meta: normalizedMeta }, cb);
 }
 
 export type McpUiReadResourceResult = ReadResourceResult & {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -41,17 +41,27 @@ import {
 } from "../app.js";
 import type {
   BaseToolCallback,
+  LegacyToolCallback,
   McpServer,
   RegisteredTool,
   ResourceMetadata,
-  ToolCallback,
+  ToolCallback as SchemaToolCallback,
   ReadResourceCallback as _ReadResourceCallback,
   RegisteredResource,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type {
   AnySchema,
   ZodRawShapeCompat,
+  StandardSchemaWithJSON,
 } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import type { ZodRawShape } from "@modelcontextprotocol/sdk";
+
+type ToolCallback<Args extends ZodRawShapeCompat | AnySchema | undefined> =
+  Args extends ZodRawShape
+    ? LegacyToolCallback<Args>
+    : Args extends StandardSchemaWithJSON
+      ? SchemaToolCallback<Args>
+      : SchemaToolCallback<undefined>;
 import type {
   ClientCapabilities,
   ReadResourceResult,
@@ -241,7 +251,12 @@ export function registerAppTool<
     normalizedMeta = { ...meta, ui: { ...uiMeta, resourceUri: legacyUri } };
   }
 
-  return server.registerTool(name, { ...config, _meta: normalizedMeta }, cb);
+  return (server.registerTool as McpServer["registerTool"])(
+    name,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { ...config, _meta: normalizedMeta } as any,
+    cb as SchemaToolCallback<undefined>,
+  );
 }
 
 export type McpUiReadResourceResult = ReadResourceResult & {


### PR DESCRIPTION
**DO NOT MERGE** — proof-of-concept port to SDK v2 using concrete `Protocol` (typescript-sdk#1891). CI is expected to fail (`package.json` depends on local `file:/tmp/*.tgz` SDK builds).

Supersedes #612 (the composition approach using #1846/#1868). Comparison:

| | #612 | this PR |
|---|---|---|
| Files changed | 105 | **20** |
| v1 `app-bridge.test.ts` tests unmodified | 73/88 | **81/88** |
| Wire-method renames | 2 | **0** |
| v1↔v2 interop shims | needed | **not needed** |
| `ProtocolWithEvents` | replaced | **kept** |

Depends on:
- modelcontextprotocol/typescript-sdk#1891 (concrete `Protocol`)
- modelcontextprotocol/typescript-sdk#1887 (`specTypeSchema`)
- modelcontextprotocol/typescript-sdk#1871 (stdio subpath)

## Motivation and Context
Validates that exporting concrete `Protocol` (typescript-sdk#1891) yields a much smaller v2 migration than the `setCustom*`/`extension()` path. `ProtocolWithEvents extends Protocol` preserved; `events.ts` shim accepts v1 envelope-schema shape and forwards to v2's 3-arg form.

## How Has This Been Tested?
Locally: tsc 0, `npm run build` 0, `npm test` 276/2/0.

## Breaking Changes
Same scope as #612 — see `BREAKING.md` (much smaller).

## Types of changes
- [x] Breaking change

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
