### PR TITLE
fix(app): autoResize collapses height:100% layouts; expose autoResize in useApp

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1391,22 +1391,30 @@ export class App extends ProtocolWithEvents<
       scheduled = true;
       requestAnimationFrame(() => {
         scheduled = false;
-        const html = document.documentElement;
+        const body = document.body;
 
-        // Measure actual content height by temporarily overriding html sizing.
-        // Height uses max-content because fit-content would clamp to the viewport
-        // height when content is taller than the iframe, causing internal scrolling.
+        // Measure content height via body.scrollHeight + vertical body margins.
         //
-        // Width uses window.innerWidth instead of measuring via fit-content.
-        // Setting html.style.width to fit-content forces a synchronous reflow at
-        // 0px width for responsive apps (whose content derives width from the
-        // container rather than having intrinsic width). This causes the browser
-        // to clamp scrollLeft on any horizontal scroll containers to 0, permanently
-        // destroying their scroll positions.
-        const originalHeight = html.style.height;
-        html.style.height = "max-content";
-        const height = Math.ceil(html.getBoundingClientRect().height);
-        html.style.height = originalHeight;
+        // scrollHeight captures overflow (so the iframe grows when content is
+        // taller than the viewport — see #525) and equals the content height for
+        // a default-styled body (so the iframe shrinks to fit — see #57).
+        //
+        // We previously forced html.style.height = "max-content" to measure
+        // intrinsic height, but that makes height:100% descendants resolve to
+        // auto during measurement. Apps that set html,body{height:100%} with a
+        // viewport-filling child reported a collapsed (spinner-sized) height
+        // and then never recovered — see #143. Reading scrollHeight without a
+        // style override leaves those layouts intact.
+        //
+        // Tradeoff: an app that sets body{height:100%} won't shrink below the
+        // current viewport height. That's the semantically correct behavior for
+        // a viewport-filling layout; apps that need explicit control should
+        // pass {autoResize: false} and call sendSizeChanged() manually.
+        const bodyStyle = getComputedStyle(body);
+        const bodyMarginY =
+          (parseFloat(bodyStyle.marginTop) || 0) +
+          (parseFloat(bodyStyle.marginBottom) || 0);
+        const height = Math.ceil(body.scrollHeight + bodyMarginY);
 
         const width = Math.ceil(window.innerWidth);
 

--- a/src/react/useApp.tsx
+++ b/src/react/useApp.tsx
@@ -7,10 +7,6 @@ export * from "../app";
 /**
  * Options for configuring the {@link useApp `useApp`} hook.
  *
- * Note: This interface does NOT expose {@link App `App`} options like `autoResize`.
- * The hook creates the `App` with default options (`autoResize: true`). If you
- * need custom `App` options, create the `App` manually instead of using this hook.
- *
  * @see {@link useApp `useApp`} for the hook that uses these options
  * @see {@link useAutoResize `useAutoResize`} for manual auto-resize control with custom `App` options
  */
@@ -21,6 +17,16 @@ export interface UseAppOptions {
    * Declares what features this app supports.
    */
   capabilities: McpUiAppCapabilities;
+  /**
+   * Automatically report size changes to the host.
+   *
+   * Disable this for apps that manage their own height (canvases, editors,
+   * diagrams) or that use viewport-relative sizing like `100vh`, and call
+   * {@link App.sendSizeChanged `app.sendSizeChanged`} manually instead.
+   *
+   * @default true
+   */
+  autoResize?: boolean;
   /**
    * Called after {@link App `App`} is created but before connection.
    *
@@ -120,6 +126,7 @@ export interface AppState {
 export function useApp({
   appInfo,
   capabilities,
+  autoResize = true,
   onAppCreated,
 }: UseAppOptions): AppState {
   const [app, setApp] = useState<App | null>(null);
@@ -135,7 +142,7 @@ export function useApp({
           window.parent,
           window.parent,
         );
-        const app = new App(appInfo, capabilities);
+        const app = new App(appInfo, capabilities, { autoResize });
 
         // Register handlers BEFORE connecting
         onAppCreated?.(app);


### PR DESCRIPTION
## Problem

`setupSizeChangedNotifications` measured content height by transiently setting `html.style.height = "max-content"`. During that synchronous reflow, any descendant with `height: 100%` resolves to `auto` (the parent now has indefinite/intrinsic size). Apps that use the common `html, body { height: 100% }` reset with a viewport-filling child therefore reported a spinner-sized height on first measure — and once the host shrank the iframe, the layout never recovered (the `100%` child now fills a tiny iframe, so `ResizeObserver` sees no further change).

## Fix

Measure `document.body.scrollHeight` + vertical body margins instead of overriding `<html>` styles.

| Case | Before (`max-content` override) | After (`body.scrollHeight`) |
|---|---|---|
| Default-styled body, content < viewport | shrinks ✅ | shrinks ✅ (#57 preserved) |
| Content > viewport | grows ✅ | grows ✅ (#525 preserved) |
| `html,body{height:100%}` + `100%` child | **collapses to spinner** ❌ | reports viewport height ✅ |
| `body{height:100%}` + short content | shrinks | stays at viewport height — semantically correct for a "fill viewport" layout |

The last row is the only behavior change for previously-working apps, and it's arguably the right behavior: an app that declares `body { height: 100% }` is asking to fill the viewport, not shrink-wrap. Apps that need explicit control should pass `{ autoResize: false }`.

## Also

- Expose `autoResize` in `UseAppOptions` so React apps can opt out without abandoning the `useApp()` hook (#502 proposal 2).

## Addresses

- #143 (collapse bug — root-caused by @kashtian)
- #189 (alternative fix removed the immediate measure; this keeps it but makes it non-destructive)
- #502 (proposal 2: `useApp({ autoResize: false })`)