### PR TITLE
build: fix pre-commit hook for symlinked self-dep and staged deletions

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,8 +15,9 @@ if grep -E '"resolved": "https?://' package-lock.json | grep -v registry.npmjs.o
 fi
 
 # Capture staged files so we only re-stage what the user intended to commit
-# (avoids sweeping unrelated WIP into the commit)
-STAGED=$(git diff --name-only --cached)
+# (avoids sweeping unrelated WIP into the commit). --diff-filter=d skips
+# deletions so the xargs git add below doesn't fail on removed paths.
+STAGED=$(git diff --name-only --cached --diff-filter=d)
 
 npm run build:all
 npm run prettier:fix

--- a/scripts/link-self.mjs
+++ b/scripts/link-self.mjs
@@ -5,10 +5,12 @@
  * so examples always type-check against the latest local types.
  * See: https://github.com/npm/feedback/discussions/774
  */
-import { cpSync, existsSync } from "fs";
+import { cpSync, existsSync, lstatSync } from "fs";
 
 const target = "node_modules/@modelcontextprotocol/ext-apps";
 if (!existsSync(target)) process.exit(0);
+// If target is a symlink (e.g. to the repo root), dist is already current.
+if (lstatSync(target).isSymbolicLink()) process.exit(0);
 
 cpSync("dist", `${target}/dist`, { recursive: true });
 cpSync("package.json", `${target}/package.json`);


### PR DESCRIPTION
## Summary

Two small pre-commit hook fixes split out of #620 / #530 where they were blocking commits:

- **`scripts/link-self.mjs`**: skip when `node_modules/@modelcontextprotocol/ext-apps` is a symlink (e.g. to the repo root). `cpSync("dist", target/dist)` was failing with `ERR_FS_CP_EINVAL` because src and dest resolved to the same path.
- **`.husky/pre-commit`**: capture staged files with `--diff-filter=d` so the `xargs git add` re-stage step doesn't fail with `fatal: pathspec ... did not match any files` on commits (typically merges) that include deletions.

## Test plan

- [x] `npm run build:all` completes with `node_modules/@modelcontextprotocol/ext-apps -> ../..` symlink in place.
- [x] Merge commit with deletions (`examples/pdf-server/plugin/**` removed) passes the hook.