### PR TITLE
fix(types): forbid csp/permissions on McpUiToolMeta via never

### DIFF
--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -5274,6 +5274,12 @@
             ],
             "description": "Tool visibility scope - who can access the tool."
           }
+        },
+        "csp": {
+          "not": {}
+        },
+        "permissions": {
+          "not": {}
         }
       },
       "additionalProperties": false

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -712,6 +712,18 @@ export const McpUiToolMetaSchema = z.object({
     .describe(
       'Who can access this tool. Default: ["model", "app"]\n- "model": Tool visible to and callable by the agent\n- "app": Tool callable by the app from this server only',
     ),
+  /**
+   * `csp` belongs on the UI **resource** (see {@link McpUiResourceMeta}),
+   * not the tool. Hosts read it from the `resources/read` content item
+   * (with `resources/list` entry as fallback) and ignore it here.
+   * @see {@link https://github.com/anthropics/claude-ai-mcp/issues/40 claude-ai-mcp#40}
+   */
+  csp: z.never().optional(),
+  /**
+   * `permissions` belongs on the UI **resource** (see {@link McpUiResourceMeta}),
+   * not the tool. Hosts ignore it here.
+   */
+  permissions: z.never().optional(),
 });
 
 /**

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -716,7 +716,6 @@ export const McpUiToolMetaSchema = z.object({
    * `csp` belongs on the UI **resource** (see {@link McpUiResourceMeta}),
    * not the tool. Hosts read it from the `resources/read` content item
    * (with `resources/list` entry as fallback) and ignore it here.
-   * @see {@link https://github.com/anthropics/claude-ai-mcp/issues/40 claude-ai-mcp#40}
    */
   csp: z.never().optional(),
   /**

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -779,7 +779,6 @@ export interface McpUiToolMeta {
    * `csp` belongs on the UI **resource** (see {@link McpUiResourceMeta}),
    * not the tool. Hosts read it from the `resources/read` content item
    * (with `resources/list` entry as fallback) and ignore it here.
-   * @see {@link https://github.com/anthropics/claude-ai-mcp/issues/40 claude-ai-mcp#40}
    */
   csp?: never;
   /**

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -775,6 +775,18 @@ export interface McpUiToolMeta {
    * - "app": Tool callable by the app from this server only
    */
   visibility?: McpUiToolVisibility[];
+  /**
+   * `csp` belongs on the UI **resource** (see {@link McpUiResourceMeta}),
+   * not the tool. Hosts read it from the `resources/read` content item
+   * (with `resources/list` entry as fallback) and ignore it here.
+   * @see {@link https://github.com/anthropics/claude-ai-mcp/issues/40 claude-ai-mcp#40}
+   */
+  csp?: never;
+  /**
+   * `permissions` belongs on the UI **resource** (see {@link McpUiResourceMeta}),
+   * not the tool. Hosts ignore it here.
+   */
+  permissions?: never;
 }
 
 /**


### PR DESCRIPTION
## Summary

Hosts read `_meta.ui.csp` and `_meta.ui.permissions` from the **resource** (`resources/read` content item, with `resources/list` entry as fallback) — never from the tool. Because `_meta.ui.resourceUri` *does* live on the tool, it's an easy mistake to put `csp` there too; doing so silently yields the default sandbox CSP.

This types `csp` and `permissions` as `?: never` on `McpUiToolMeta`, with JSDoc pointing at `McpUiResourceMeta`. Preventive — not tied to a specific bug report.

### Why `never` and not just rely on excess property checking?

For **direct object literals** — the common `registerAppTool(s, { _meta: { ui: { resourceUri, csp } } })` case — TypeScript's excess property check already errors without this change. The `never` adds value in two places:

- **Indirect assignment** (config built in a variable, spread from a shared object, returned from a helper): structural typing allows extra keys, so `const ui = { resourceUri, csp }; registerAppTool(s, { _meta: { ui } })` typechecks clean on `main` today. With `never`, it fails with `Type '{...csp...}' is not assignable to 'McpUiToolMeta'`.
- **JSDoc on the forbidden field**: the excess-property error only says "`csp` does not exist in type `McpUiToolMeta`"; the `never` field's hover/docs say *where it actually belongs*.

Generated Zod emits `z.never().optional()`; `McpUiToolMetaSchema` is exported but not `.parse()`'d anywhere in the SDK or host today, so this is dormant at runtime.

A companion host-side change adds a `console.warn` for non-TypeScript servers.

## Test plan

- [x] `npm run generate:schemas` — `never` → `"not": {}` in schema.json.
- [x] `bun test` — 106/106 pass.
- [x] Verified empirically: indirect assignment typechecks clean on `main`, errors with TS2322 on this branch.
- [ ] CI typedoc validation.