### PR TITLE
chore: drop GitHub issue URLs from pre-handshake guard log messages

### DIFF
--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -336,8 +336,7 @@ export class AppBridge extends ProtocolWithEvents<
           `[ext-apps] AppBridge received '${request.method}' before ` +
             `ui/notifications/initialized. The View is calling host ` +
             `methods before completing the handshake; it should await ` +
-            `app.connect() first. See ` +
-            `https://github.com/anthropics/claude-ai-mcp/issues/149`,
+            `app.connect() first.`,
         );
       }
       return handler(request, extra);

--- a/src/app.ts
+++ b/src/app.ts
@@ -280,8 +280,7 @@ export class App extends ProtocolWithEvents<
     const msg =
       `[ext-apps] App.${method}() called before connect() completed the ` +
       `ui/initialize handshake. Await app.connect() before calling this ` +
-      `method, or move data loading to an ontoolresult handler. ` +
-      `See https://github.com/anthropics/claude-ai-mcp/issues/149`;
+      `method, or move data loading to an ontoolresult handler.`;
     if (this.options?.strict) {
       throw new Error(msg);
     }


### PR DESCRIPTION
## Summary

Follow-up to #623. The runtime `console.error` / `console.warn` strings in `App._assertInitialized` and the `AppBridge.replaceRequestHandler` override included a link to a tracking issue. Issue URLs in runtime logs are brittle (issues get closed/locked) and send developers to a discussion thread rather than actionable docs; the message itself already says what to do ("await `app.connect()`, or move data loading to an `ontoolresult` handler"). The JSDoc `@see` links on the private members are kept.

## Test plan

- [x] `bun test src/app-bridge.test.ts` — 94/94 pass (test regex doesn't match the URL).