### PR TITLE
docs(types): drop stale resourceUri JSDoc referencing deprecated flat key

### DIFF
--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -711,7 +711,6 @@ export const McpUiToolVisibilitySchema = z
 export const McpUiToolMetaSchema = z.object({
   /**
    * URI of the UI resource to display for this tool, if any.
-   * This is converted to `_meta["ui/resourceUri"]`.
    *
    * @example
    * ```ts

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -769,7 +769,6 @@ export type McpUiToolVisibility = "model" | "app";
 export interface McpUiToolMeta {
   /**
    * URI of the UI resource to display for this tool, if any.
-   * This is converted to `_meta["ui/resourceUri"]`.
    *
    * @example
    * ```ts


### PR DESCRIPTION
The JSDoc on `McpUiToolMeta.resourceUri` said it "is converted to `_meta["ui/resourceUri"]`" — that's the deprecated flat key, and there's no conversion (`McpUiToolMeta` is the type of `_meta.ui` itself). Dropped the line.