### PR TITLE
docs: add community-examples page

### DIFF
--- a/docs/community-examples.md
+++ b/docs/community-examples.md
@@ -1,0 +1,41 @@
+---
+title: Community Examples
+group: Documents
+---
+
+# Community Examples
+
+The `examples/` directory in this repository is kept to a minimal set that
+exercises specific SDK capabilities (see
+[CONTRIBUTING.md](https://github.com/modelcontextprotocol/ext-apps/blob/main/CONTRIBUTING.md#examples)).
+Domain-specific apps, alternative-stack hosts, and framework templates beyond
+that set are linked here instead, and remain maintained by their authors.
+
+To add yours, open a PR editing this file with a one-line entry.
+
+## Apps
+
+| Name                             | Stack                       | Author                                           | Links                                                                |
+| -------------------------------- | --------------------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
+| DICOM Viewer                     | React, dicom-parser         | [@ThalesMMS](https://github.com/ThalesMMS)       | [PR #405](https://github.com/modelcontextprotocol/ext-apps/pull/405) |
+| D3 Force Graph                   | Vanilla JS, D3              | [@iamfiscus](https://github.com/iamfiscus)       | [PR #214](https://github.com/modelcontextprotocol/ext-apps/pull/214) |
+| Recharts Dashboard               | React, Recharts             | [@iamfiscus](https://github.com/iamfiscus)       | [PR #214](https://github.com/modelcontextprotocol/ext-apps/pull/214) |
+| Stitch Design Integration        | React                       | [@jayeshvpatil](https://github.com/jayeshvpatil) | [PR #468](https://github.com/modelcontextprotocol/ext-apps/pull/468) |
+| Calculator (Java/WebFlux server) | Spring Boot, MCP Java SDK   | [@apappascs](https://github.com/apappascs)       | [PR #439](https://github.com/modelcontextprotocol/ext-apps/pull/439) |
+| Zero-dependency MCP App          | None (no SDK, raw protocol) | [@janwilmake](https://github.com/janwilmake)     | [PR #519](https://github.com/modelcontextprotocol/ext-apps/pull/519) |
+
+## Hosts
+
+| Name                        | Stack               | Author                               | Links                                                                                                                 |
+| --------------------------- | ------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| ASP.NET Core + Angular host | .NET 10, Angular 21 | [@halllo](https://github.com/halllo) | [PR #610](https://github.com/modelcontextprotocol/ext-apps/pull/610) · [repo](https://github.com/halllo/mcp-ext-apps) |
+
+## Framework templates
+
+| Name                 | Stack                | Author                                   | Links                                                                |
+| -------------------- | -------------------- | ---------------------------------------- | -------------------------------------------------------------------- |
+| basic-server-angular | Angular 21, AnalogJS | [@Avcharov](https://github.com/Avcharov) | [PR #453](https://github.com/modelcontextprotocol/ext-apps/pull/453) |
+
+> **Note for authors:** entries above currently link to the original PR for
+> reference. If you publish your example as a standalone repository, open a PR
+> to swap the link — a dedicated repo is easier for others to clone and run.

--- a/typedoc.config.mjs
+++ b/typedoc.config.mjs
@@ -17,6 +17,7 @@ const config = {
     "docs/authorization.md",
     "docs/csp-cors.md",
     "docs/migrate_from_openai_apps.md",
+    "docs/community-examples.md",
   ],
   entryPoints: [
     "src/server/index.ts",


### PR DESCRIPTION
## Summary

- Adds `docs/community-examples.md` — a linked index of community-maintained example apps, hosts, and framework templates, per the examples policy merged in #550.
- Seeded with 8 entries from open/closed example PRs (#405, #214, #468, #439, #519, #610, #453) so we can point authors here when declining in-tree maintenance.
- Wired into `typedoc.config.mjs` `projectDocuments` so it appears on the docs site.

Authors are encouraged to swap PR links for standalone-repo links once published.

## Test plan

- [x] `npm exec typedoc -- --treatValidationWarningsAsErrors --emit none` passes
- [ ] Docs site preview renders the new page under Documents