### PR TITLE
fix(basic-host): accept Safari same-origin event.source in sandbox relay

### DIFF
--- a/examples/basic-host/src/sandbox.ts
+++ b/examples/basic-host/src/sandbox.ts
@@ -112,7 +112,14 @@ window.addEventListener("message", async (event) => {
         inner.contentWindow.postMessage(event.data, "*");
       }
     }
-  } else if (event.source === inner.contentWindow) {
+  } else if (
+    event.source === inner.contentWindow ||
+    // Safari/WebKit can surface inner-iframe messages with `event.source ===
+    // window` (the sandbox's own window) instead of `inner.contentWindow` in
+    // nested same-origin setups. Origin is the real security boundary here —
+    // the sandbox runs on its own dedicated origin — so accept that case too.
+    (event.origin === OWN_ORIGIN && event.source === window)
+  ) {
     if (event.origin !== OWN_ORIGIN) {
       console.error(
         "[Sandbox] Rejecting message from inner iframe with unexpected origin:",


### PR DESCRIPTION
## Summary

Safari/WebKit can surface inner-iframe messages at the sandbox relay with `event.source === window` (the sandbox's own window) rather than `inner.contentWindow`. The strict source-identity check at `sandbox.ts:115` then drops the View's `ui/initialize`, and the handshake never completes — Chromium-based hosts render fine, Safari desktop / iOS WebKit / mobile-native do not.

Accept that case when `event.origin === OWN_ORIGIN`. The sandbox runs on its own dedicated origin, so origin is the actual security boundary; source-identity was a belt-and-braces check that turns out to be brittle on WebKit. The existing inner `event.origin !== OWN_ORIGIN` rejection still applies.

Diagnosis and fix by @kentcdodds — see the runtime evidence in https://github.com/modelcontextprotocol/ext-apps/issues/542#issuecomment-4248280733.

This is **separate** from the #542 srcdoc construction-timing race (host attaches its listener after the View has already posted), which is being addressed via host-construction-order docs/helper instead of a deferred-target transport (see discussion on #543).

## Test plan

- [x] `npm run --workspace examples/basic-host build` — compiles
- [ ] Manual Safari verification: load basic-host in Safari, confirm an example View completes `ui/initialize` and renders
- [ ] Spot-check Chromium still works (no regression in existing e2e)