### PR TITLE
fix(wiki-explorer): prevent path-traversal SSRF bypass in URL validation

### DIFF
--- a/examples/wiki-explorer-server/server.test.ts
+++ b/examples/wiki-explorer-server/server.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "./server";
+
+function firstText(r: Awaited<ReturnType<Client["callTool"]>>): string {
+  return (r.content as Array<{ type: string; text: string }>)[0].text;
+}
+
+describe("wiki-explorer URL validation", () => {
+  let server: ReturnType<typeof createServer>;
+  let client: Client;
+
+  beforeEach(async () => {
+    server = createServer();
+    client = new Client({ name: "test", version: "1" });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(st), client.connect(ct)]);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("rejects non-Wikipedia URLs", async () => {
+    const r = await client.callTool({
+      name: "get-first-degree-links",
+      arguments: { url: "https://evil.com/wiki/Test" },
+    });
+    const result = JSON.parse(firstText(r));
+    expect(result.error).toBe("Not a valid Wikipedia URL");
+  });
+
+  it("rejects path traversal that escapes /wiki/", async () => {
+    // This URL passes the old regex but resolves to /w/api.php (outside /wiki/)
+    const r = await client.callTool({
+      name: "get-first-degree-links",
+      arguments: {
+        url: "https://en.wikipedia.org/wiki/../../w/api.php?action=query&list=allusers",
+      },
+    });
+    const result = JSON.parse(firstText(r));
+    expect(result.error).toBe("Not a valid Wikipedia URL");
+  });
+
+  it("rejects path traversal to API endpoints", async () => {
+    const r = await client.callTool({
+      name: "get-first-degree-links",
+      arguments: {
+        url: "https://en.wikipedia.org/wiki/../../../api/rest_v1/feed/featured/2024/01/01",
+      },
+    });
+    const result = JSON.parse(firstText(r));
+    expect(result.error).toBe("Not a valid Wikipedia URL");
+  });
+
+  it("accepts valid Wikipedia URLs", async () => {
+    // Mock fetch to avoid real network requests
+    const mockFetch = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("<html><body><a href='/wiki/Test'>Test</a></body></html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+
+    try {
+      const r = await client.callTool({
+        name: "get-first-degree-links",
+        arguments: {
+          url: "https://en.wikipedia.org/wiki/Model_Context_Protocol",
+        },
+      });
+      const result = JSON.parse(firstText(r));
+      expect(result.error).toBeNull();
+      expect(result.page.url).toBe(
+        "https://en.wikipedia.org/wiki/Model_Context_Protocol",
+      );
+    } finally {
+      mockFetch.mockRestore();
+    }
+  });
+
+  it("disables redirect following on fetch", async () => {
+    // Ensure fetch is called with redirect: 'error' or 'manual' to prevent
+    // following redirects to non-Wikipedia domains
+    const mockFetch = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("<html><body></body></html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+
+    try {
+      await client.callTool({
+        name: "get-first-degree-links",
+        arguments: {
+          url: "https://en.wikipedia.org/wiki/Test_Page",
+        },
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const fetchArgs = mockFetch.mock.calls[0];
+      // Second argument should have redirect: "error"
+      expect(fetchArgs[1]).toBeDefined();
+      expect((fetchArgs[1] as RequestInit).redirect).toBe("error");
+    } finally {
+      mockFetch.mockRestore();
+    }
+  });
+});

--- a/examples/wiki-explorer-server/server.ts
+++ b/examples/wiki-explorer-server/server.ts
@@ -31,6 +31,37 @@ function extractTitleFromUrl(url: string): string {
   }
 }
 
+/**
+ * Validate that a URL points to a Wikipedia wiki page.
+ * Uses parsed URL components (not raw string matching) to prevent
+ * path-traversal bypasses such as `/wiki/../../w/api.php`.
+ */
+function isValidWikipediaUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  // Protocol must be HTTPS (or HTTP for dev, matching prior behaviour)
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return false;
+  }
+
+  // Hostname must be <lang>.wikipedia.org — language codes are lowercase ASCII
+  if (!/^[a-z]+\.wikipedia\.org$/.test(parsed.hostname)) {
+    return false;
+  }
+
+  // After URL resolution, the pathname must still start with /wiki/
+  if (!parsed.pathname.startsWith("/wiki/")) {
+    return false;
+  }
+
+  return true;
+}
+
 // Wikipedia namespace prefixes to exclude from link extraction
 const EXCLUDED_PREFIXES = [
   "Wikipedia:",
@@ -113,13 +144,13 @@ export function createServer(): McpServer {
       let title = url;
 
       try {
-        if (!url.match(/^https?:\/\/[a-z]+\.wikipedia\.org\/wiki\//)) {
+        if (!isValidWikipediaUrl(url)) {
           throw new Error("Not a valid Wikipedia URL");
         }
 
         title = extractTitleFromUrl(url);
 
-        const response = await fetch(url);
+        const response = await fetch(url, { redirect: "error" });
 
         if (!response.ok) {
           throw new Error(


### PR DESCRIPTION
## Summary

The `get-first-degree-links` tool in `examples/wiki-explorer-server` validates the user-supplied `url` argument with a regex applied to the raw string:

```ts
if (!url.match(/^https?:\/\/[a-z]+\.wikipedia\.org\/wiki\//)) {
  throw new Error("Not a valid Wikipedia URL");
}
// ...
const response = await fetch(url);
```

A URL like `https://en.wikipedia.org/wiki/../../w/api.php?action=query&list=allusers` matches this regex, but `fetch()` performs WHATWG URL normalization which collapses the `../..` segments. The request that actually leaves the server targets `https://en.wikipedia.org/w/api.php?...` — the MediaWiki API, which the `/wiki/` filter was meant to keep out of reach.

Confirmed in a Node REPL:

```
> new URL("https://en.wikipedia.org/wiki/../../w/api.php?action=query&list=allusers").pathname
'/w/api.php'
```

- **CWE:** CWE-918 (Server-Side Request Forgery) — scoped variant
- **File / function:** `examples/wiki-explorer-server/server.ts`, `get-first-degree-links` tool handler
- **Data flow:** tool `arguments.url` (attacker-controlled) → regex check (string-level only) → `fetch(url)` (URL-normalized) → response body returned to the caller

## Impact (honest scoping)

The host regex itself is correct and unchanged, so the request still lands on `*.wikipedia.org`. This is not a classic SSRF that reaches `127.0.0.1` or cloud metadata. The realistic impact is that an LLM-supplied argument can cause the tool to hit MediaWiki API endpoints (e.g. `action=query&list=allusers`) and surface their JSON/HTML response as if it were a Wikipedia article — bypassing the namespace allowlist the tool tries to enforce, and producing unexpected data in the model's context. It's a defensive hardening fix rather than a critical SSRF, but the bypass of the explicit `/wiki/` filter is real.

## Fix

Two small, targeted changes in `server.ts`:

1. Replace the raw-string regex with a parsed-URL check (`isValidWikipediaUrl`) that validates `parsed.protocol`, `parsed.hostname`, and crucially `parsed.pathname.startsWith("/wiki/")` *after* normalization. This closes the path-traversal bypass.
2. Pass `{ redirect: "error" }` to `fetch()` so a Wikipedia redirect cannot be used to send the request to a different host or path that the validator never saw.

The host allowlist (`<lang>.wikipedia.org`) is preserved exactly.

## Tests

Added `examples/wiki-explorer-server/server.test.ts` with cases that:

- reject non-Wikipedia hosts (`https://evil.com/wiki/Test`)
- reject the path-traversal payload that bypassed the old regex (`https://en.wikipedia.org/wiki/../../w/api.php?...`)
- reject non-`/wiki/` paths on a valid host
- accept legitimate article URLs

The traversal test fails against the old code and passes against the patched code.

## Adversarial review

Before submitting we tried to talk ourselves out of this. The host check is unchanged and correct, so reachable targets are still limited to public Wikipedia mirrors — there's no path to internal services or cloud metadata. The server is an example MCP server typically run locally over stdio, so the attacker model is "a malicious tool-call argument coming from the LLM/client", not a remote network attacker. We still think it's worth fixing: the `/wiki/` namespace filter is a security boundary the tool explicitly tries to enforce, the bypass is trivial to trigger, and the fix is two lines plus tests with no behaviour change for legitimate URLs.

cc @lewiswigmore
