### PR TITLE
chore(pdf-server): switch to maintained @cantoo/pdf-lib fork

### DIFF
--- a/examples/pdf-server/package.json
+++ b/examples/pdf-server/package.json
@@ -25,11 +25,11 @@
     "build:mcpb": "npm run build && node build-mcpb.mjs"
   },
   "dependencies": {
+    "@cantoo/pdf-lib": "^2.6.5",
     "@modelcontextprotocol/ext-apps": "^1.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^5.0.0",
     "zod": "^4.1.13"
   },

--- a/examples/pdf-server/server.test.ts
+++ b/examples/pdf-server/server.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
-import { PDFDocument } from "pdf-lib";
+import { PDFDocument } from "@cantoo/pdf-lib";
 import { makeRandomJpeg } from "../../tests/helpers/range-counting-server";
 import {
   createPdfCache,

--- a/examples/pdf-server/src/pdf-annotations.test.ts
+++ b/examples/pdf-server/src/pdf-annotations.test.ts
@@ -18,7 +18,13 @@ import {
   type PdfAnnotationDef,
   type AnnotationDiff,
 } from "./pdf-annotations";
-import { PDFDocument, PDFDict, PDFName, PDFArray, PDFNumber } from "pdf-lib";
+import {
+  PDFDocument,
+  PDFDict,
+  PDFName,
+  PDFArray,
+  PDFNumber,
+} from "@cantoo/pdf-lib";
 
 // =============================================================================
 // Diff Model
@@ -1074,16 +1080,16 @@ describe("buildAnnotatedPdfBytes", () => {
     // Check /C (stroke color) = [1, 0, 0] for #ff0000
     const cArr = annotDict.get(PDFName.of("C")) as PDFArray;
     expect(cArr).toBeDefined();
-    expect((cArr.get(0) as PDFNumber).value()).toBe(1); // r
-    expect((cArr.get(1) as PDFNumber).value()).toBe(0); // g
-    expect((cArr.get(2) as PDFNumber).value()).toBe(0); // b
+    expect((cArr.get(0) as PDFNumber).asNumber()).toBe(1); // r
+    expect((cArr.get(1) as PDFNumber).asNumber()).toBe(0); // g
+    expect((cArr.get(2) as PDFNumber).asNumber()).toBe(0); // b
 
     // Check /IC (fill color) = [0, 1, 0] for #00ff00
     const icArr = annotDict.get(PDFName.of("IC")) as PDFArray;
     expect(icArr).toBeDefined();
-    expect((icArr.get(0) as PDFNumber).value()).toBe(0); // r
-    expect((icArr.get(1) as PDFNumber).value()).toBe(1); // g
-    expect((icArr.get(2) as PDFNumber).value()).toBe(0); // b
+    expect((icArr.get(0) as PDFNumber).asNumber()).toBe(0); // r
+    expect((icArr.get(1) as PDFNumber).asNumber()).toBe(1); // g
+    expect((icArr.get(2) as PDFNumber).asNumber()).toBe(0); // b
   });
 
   it("adds freetext annotation to PDF", async () => {
@@ -1159,9 +1165,9 @@ describe("buildAnnotatedPdfBytes", () => {
     // Check /C color
     const cArr = annotDict.get(PDFName.of("C")) as PDFArray;
     expect(cArr).toBeDefined();
-    expect((cArr.get(0) as PDFNumber).value()).toBe(0);
-    expect((cArr.get(1) as PDFNumber).value()).toBe(1);
-    expect((cArr.get(2) as PDFNumber).value()).toBe(0);
+    expect((cArr.get(0) as PDFNumber).asNumber()).toBe(0);
+    expect((cArr.get(1) as PDFNumber).asNumber()).toBe(1);
+    expect((cArr.get(2) as PDFNumber).asNumber()).toBe(0);
 
     // Check appearance stream exists and contains the color
     const ap = annotDict.get(PDFName.of("AP")) as PDFDict;

--- a/examples/pdf-server/src/pdf-annotations.ts
+++ b/examples/pdf-server/src/pdf-annotations.ts
@@ -24,7 +24,7 @@ import {
   PDFOptionList,
   PDFRadioGroup,
   type PDFForm,
-} from "pdf-lib";
+} from "@cantoo/pdf-lib";
 
 // =============================================================================
 // Types

--- a/package-lock.json
+++ b/package-lock.json
@@ -638,11 +638,11 @@
       "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
+        "@cantoo/pdf-lib": "^2.6.5",
         "@modelcontextprotocol/ext-apps": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^5.0.0",
         "zod": "^4.1.13"
       },
@@ -1487,6 +1487,21 @@
         "mermaid": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@cantoo/pdf-lib": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@cantoo/pdf-lib/-/pdf-lib-2.6.5.tgz",
+      "integrity": "sha512-3eMHEaqKHt/G/q+6QjT06A3lz0S/a8x3+myiSN7FNeL3uWcedO0lpfs6TWofa4C03Z1wz3tWeHoa4CsI7DrTSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "color": "^4.2.3",
+        "crypto-js": "^4.2.0",
+        "node-html-better-parser": ">=1.4.0",
+        "pako": "^1.0.11",
+        "tslib": ">=2"
       }
     },
     "node_modules/@clack/core": {
@@ -5115,11 +5130,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5132,8 +5159,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -5265,6 +5301,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -6342,7 +6384,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
       "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
@@ -6488,6 +6529,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -7127,6 +7174,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-html-better-parser": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/node-html-better-parser/-/node-html-better-parser-1.5.8.tgz",
+      "integrity": "sha512-t/wAKvaTSKco43X+yf9+76RiMt18MtMmzd4wc7rKj+fWav6DV4ajDEKdWlLzSE8USDF5zr/06uGj0Wr/dGAFtw==",
+      "license": "MIT",
+      "dependencies": {
+        "html-entities": "^2.3.2"
+      }
+    },
     "node_modules/node-html-parser": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
@@ -7376,24 +7432,6 @@
       "engines": {
         "node": ">= 14.16"
       }
-    },
-    "node_modules/pdf-lib": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
-      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@pdf-lib/standard-fonts": "^1.0.0",
-        "@pdf-lib/upng": "^1.0.1",
-        "pako": "^1.0.11",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/pdf-lib/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/pdfjs-dist": {
       "version": "5.4.530",
@@ -8065,6 +8103,15 @@
       "license": "MIT",
       "dependencies": {
         "kolorist": "^1.6.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/simple-update-notifier": {
@@ -8751,7 +8798,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {

--- a/tests/helpers/range-counting-server.ts
+++ b/tests/helpers/range-counting-server.ts
@@ -8,7 +8,12 @@
  */
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { PDFDocument, PDFName, PDFString, StandardFonts } from "pdf-lib";
+import {
+  PDFDocument,
+  PDFName,
+  PDFString,
+  StandardFonts,
+} from "@cantoo/pdf-lib";
 
 export interface RangeServerStats {
   /** Total bytes written across all responses (sum of slice lengths). */


### PR DESCRIPTION
## Summary

- Replaces `pdf-lib@1.17.1` (unmaintained since Nov 2021) with `@cantoo/pdf-lib@^2.6.5` in `examples/pdf-server`
- Updates 4 import sites (`pdf-annotations.ts`, two test files, `tests/helpers/range-counting-server.ts`)
- Replaces deprecated `PDFNumber.value()` with `PDFNumber.asNumber()` in test assertions

## Why

`pdf-lib` has had no release in 4+ years (see [Hopding/pdf-lib#1423](https://github.com/Hopding/pdf-lib/issues/1423)). [`@cantoo/pdf-lib`](https://github.com/cantoo-scribe/pdf-lib) is the community-recognized successor: ~180k downloads/week, 12 releases in the last 8 months, MIT-licensed, drop-in API compatible. Snyk and `npm audit` both report 0 vulnerabilities for the fork and its transitive deps.

Supply-chain scanners flag pdf-lib's `dist/pdf-lib.esm.min.js` as "obfuscated code" — that is a false positive on terser-minified output (no `eval`/`Function`/`atob`, sourcemap present), and the file is CDN-only (`unpkg` field), never loaded by Node or our Vite/bun builds. **The fork ships the same `dist/` layout, so this PR does not clear that scanner finding** — it should be allowlisted separately. This PR is about moving to a maintained dependency.

New transitive deps: `color`, `crypto-js@^4.2.0`, `node-html-better-parser` (used by the fork's SVG/encryption features; all audited clean).

## Test plan

- [x] `npm run --workspace examples/pdf-server build` — typecheck + Vite + bun bundle all green
- [x] `npm test` — 374 pass / 0 fail
- [x] `npm run test:e2e` — all green incl. PDF Server "loads app UI" + "screenshot matches golden"
- [x] Verified all 14 pdf-lib exports we use are present in the fork
- [x] `npm audit` — no new advisories introduced (pre-existing `postcss` finding is unrelated, comes from Vite/Vue)