### PR TITLE
feat(types,spec): add tools field to McpUiHostCapabilities

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -660,6 +660,18 @@ interface HostCapabilities {
     /** Host supports resources/list_changed notifications. */
     listChanged?: boolean;
   };
+  /**
+   * Host supports calling tools declared by the app (oncalltool/onlisttools).
+   * When present, the host MUST:
+   * 1. Call tools/list on the app after connect and surface results to the LLM.
+   * 2. Route LLM tool calls matching app-declared tool names back to the app via tools/call.
+   * 3. If listChanged is true: re-query tools/list when it receives a
+   *    notifications/tools/list_changed notification from the app.
+   */
+  tools?: {
+    /** Host will re-query tools/list when it receives notifications/tools/list_changed from the app. */
+    listChanged?: boolean;
+  };
   /** Host accepts log messages. */
   logging?: {};
   /** Sandbox configuration applied by the host. */

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -508,6 +508,11 @@ export interface McpUiHostCapabilities {
     /** @description Host supports resources/list_changed notifications. */
     listChanged?: boolean;
   };
+  /** @description Host supports calling tools declared by the app (oncalltool/onlisttools). When present, the host will call tools/list on the app after connect, surface the results to the LLM, and route matching tool calls back to the app via tools/call. */
+  tools?: {
+    /** @description Host supports tools/list_changed notifications from the app and will re-query tools/list when received. */
+    listChanged?: boolean;
+  };
   /** @description Host accepts log messages. */
   logging?: {};
   /** @description Sandbox configuration applied by the host. */


### PR DESCRIPTION
Closes #655.

## Problem

`McpUiAppCapabilities` allows widgets to declare `tools: {}` signalling they expose `oncalltool`/`onlisttools`, but `McpUiHostCapabilities` has no corresponding field. The handshake is one-sided:

- Widgets can declare intent (`tools: {}` in `ui/initialize`)
- Hosts have no spec-defined way to advertise they will honor it
- Widgets cannot gate on `getHostCapabilities()?.tools` because the field doesn't exist
- No known host implements `bridge.listTools()` — the spec gap is likely a contributing factor

## Fix

Add `tools?: { listChanged?: boolean }` to `McpUiHostCapabilities` in both `src/spec.types.ts` and `specification/draft/apps.mdx`, with MUST-level requirements describing what a host advertising this capability is expected to implement:

1. Call `tools/list` on the app after connect and surface results to the LLM
2. Route LLM tool calls matching app-declared tool names back to the app via `tools/call`
3. Re-query `tools/list` on `notifications/tools/list_changed` from the app (if `listChanged: true`)

## Precedent

This follows the same pattern as PR #653, which added `updateModelContext` and `message` to `McpUiHostCapabilities` — fields that were already in the TypeScript types but missing from the spec document.