### PR TITLE
Fix broken documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -502,7 +502,7 @@ Alternatively, use the [workflow dispatch](https://github.com/modelcontextprotoc
 
 ## Code of Conduct
 
-This project follows our [Code of Conduct](CODE_OF_CONDUCT.md). Please review it before contributing.
+This project follows our [Code of Conduct](https://github.com/modelcontextprotocol/.github/blob/main/CODE_OF_CONDUCT.md). Please review it before contributing.
 
 ## Reporting Issues
 

--- a/examples/map-server/README.md
+++ b/examples/map-server/README.md
@@ -122,7 +122,7 @@ Vanilla TypeScript app that:
 
 - [`server.ts`](server.ts) - MCP server with geocode and show-map tools
 - [`mcp-app.html`](mcp-app.html) / [`src/mcp-app.ts`](src/mcp-app.ts) - CesiumJS globe UI
-- [`server-utils.ts`](server-utils.ts) - HTTP server utilities
+- [`main.ts`](main.ts) - HTTP and stdio server utilities
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- point the contributor Code of Conduct link to the MCP organization Code of Conduct
- update the map-server README to link to the existing main.ts transport utilities file

## Verification
- checked local Markdown links in the changed files
- git diff --check