### PR TITLE
chore: bump example transitives to latest patches

### DIFF
--- a/examples/basic-server-solid/package.json
+++ b/examples/basic-server-solid/package.json
@@ -40,7 +40,7 @@
     "typescript": "^5.9.3",
     "vite": "^6.0.0",
     "vite-plugin-singlefile": "^2.3.0",
-    "vite-plugin-solid": "^2.0.0"
+    "vite-plugin-solid": "^2.11.12"
   },
   "types": "dist/server.d.ts",
   "exports": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -222,7 +222,7 @@
         "typescript": "^5.9.3",
         "vite": "^6.0.0",
         "vite-plugin-singlefile": "^2.3.0",
-        "vite-plugin-solid": "^2.0.0"
+        "vite-plugin-solid": "^2.11.12"
       }
     },
     "examples/basic-server-solid/node_modules/@types/node": {
@@ -2562,35 +2562,21 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/ext-apps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.0.0.tgz",
-      "integrity": "sha512-d5vGKBhWkRoa3xlKOynF8kd+sTSY2D3QSjTMCs46/ddOUOSn5e/E0SaShixFm7H7mNlj4uY0RuU0jAsPM/0qwA==",
-      "hasInstallScript": true,
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.1.tgz",
+      "integrity": "sha512-J3WdG1A4JSSKnSWKyU+895dBVYBV2Utgtf7fUsUK45mlkETm53a/1DR6Pm3hUGKqLLQthZLmpxOg8VPzJi/lyg==",
       "license": "MIT",
       "workspaces": [
         "examples/*"
       ],
-      "optionalDependencies": {
-        "@oven/bun-darwin-aarch64": "^1.2.21",
-        "@oven/bun-darwin-x64": "^1.2.21",
-        "@oven/bun-darwin-x64-baseline": "^1.2.21",
-        "@oven/bun-linux-aarch64": "^1.2.21",
-        "@oven/bun-linux-aarch64-musl": "^1.2.21",
-        "@oven/bun-linux-x64": "^1.2.21",
-        "@oven/bun-linux-x64-baseline": "^1.2.21",
-        "@oven/bun-linux-x64-musl": "^1.2.21",
-        "@oven/bun-linux-x64-musl-baseline": "^1.2.21",
-        "@oven/bun-windows-x64": "^1.2.21",
-        "@oven/bun-windows-x64-baseline": "^1.2.21",
-        "@rollup/rollup-darwin-arm64": "^4.53.3",
-        "@rollup/rollup-darwin-x64": "^4.53.3",
-        "@rollup/rollup-linux-arm64-gnu": "^4.53.3",
-        "@rollup/rollup-linux-x64-gnu": "^4.53.3",
-        "@rollup/rollup-win32-arm64-msvc": "^4.53.3",
-        "@rollup/rollup-win32-x64-msvc": "^4.53.3"
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.24.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "zod": "^3.25.0 || ^4.0.0"
@@ -3053,6 +3039,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3066,6 +3053,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3079,6 +3067,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3092,6 +3081,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3105,6 +3095,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3118,6 +3109,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3131,6 +3123,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3144,6 +3137,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3157,6 +3151,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3184,6 +3179,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3197,6 +3193,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3356,6 +3353,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3369,6 +3367,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3438,6 +3437,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3563,6 +3563,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3618,6 +3619,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3659,6 +3661,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4538,9 +4541,9 @@
       }
     },
     "node_modules/babel-plugin-jsx-dom-expressions": {
-      "version": "0.40.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.3.tgz",
-      "integrity": "sha512-5HOwwt0BYiv/zxl7j8Pf2bGL6rDXfV6nUhLs8ygBX+EFJXzBPHM/euj9j/6deMZ6wa52Wb2PBaAV5U/jKwIY1w==",
+      "version": "0.40.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.6.tgz",
+      "integrity": "sha512-v3P1MW46Lm7VMpAkq0QfyzLWWkC8fh+0aE5Km4msIgDx5kjenHU0pF2s+4/NH8CQn/kla6+Hvws+2AF7bfV5qQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4578,17 +4581,17 @@
       }
     },
     "node_modules/babel-preset-solid": {
-      "version": "1.9.10",
-      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.10.tgz",
-      "integrity": "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==",
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.12.tgz",
+      "integrity": "sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "babel-plugin-jsx-dom-expressions": "^0.40.3"
+        "babel-plugin-jsx-dom-expressions": "^0.40.6"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0",
-        "solid-js": "^1.9.10"
+        "solid-js": "^1.9.12"
       },
       "peerDependenciesMeta": {
         "solid-js": {
@@ -9626,9 +9629,9 @@
       }
     },
     "node_modules/vite-plugin-solid": {
-      "version": "2.11.10",
-      "resolved": "https://registry.npmjs.org/vite-plugin-solid/-/vite-plugin-solid-2.11.10.tgz",
-      "integrity": "sha512-Yr1dQybmtDtDAHkii6hXuc1oVH9CPcS/Zb2jN/P36qqcrkNnVPsMTzQ06jyzFPFjj3U1IYKMVt/9ZqcwGCEbjw==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/vite-plugin-solid/-/vite-plugin-solid-2.11.12.tgz",
+      "integrity": "sha512-FgjPcx2OwX9h6f28jli7A4bG7PP3te8uyakE5iqsmpq3Jqi1TWLgSroC9N6cMfGRU2zXsl4Q6ISvTr2VL0QHpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9642,7 +9645,7 @@
       "peerDependencies": {
         "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*",
         "solid-js": "^1.7.2",
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@testing-library/jest-dom": {
@@ -9651,9 +9654,9 @@
       }
     },
     "node_modules/vite-prerender-plugin": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/vite-prerender-plugin/-/vite-prerender-plugin-0.5.12.tgz",
-      "integrity": "sha512-EiwhbMn+flg14EysbLTmZSzq8NGTxhytgK3bf4aGRF1evWLGwZiHiUJ1KZDvbxgKbMf2pG6fJWGEa3UZXOnR1g==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/vite-prerender-plugin/-/vite-prerender-plugin-0.5.13.tgz",
+      "integrity": "sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9665,7 +9668,7 @@
         "stack-trace": "^1.0.0-pre2"
       },
       "peerDependencies": {
-        "vite": "5.x || 6.x || 7.x"
+        "vite": "5.x || 6.x || 7.x || 8.x"
       }
     },
     "node_modules/vite/node_modules/fdir": {


### PR DESCRIPTION
Routine patch bumps for example workspace transitives, all within existing semver ranges:

- `vite-plugin-solid` 2.11.10 → 2.11.12 (`basic-server-solid`)
- `babel-preset-solid` 1.9.10 → 1.9.12
- `babel-plugin-jsx-dom-expressions` 0.40.3 → 0.40.6
- `vite-prerender-plugin` 0.5.12 → 0.5.13 (`basic-server-preact`)
- `@modelcontextprotocol/ext-apps` lockfile entry 1.0.0 → 1.7.1 — the lockfile carried a stale registry pin of the repo's own published package that was never updated alongside `package.json` version bumps. Examples resolve `@modelcontextprotocol/ext-apps` from the registry, not the workspace, so this entry needs to track releases.

Tightens the `basic-server-solid` lower bound to `^2.11.12` to track the patch series with current Solid HMR fixes.

Verified `basic-server-solid` and `basic-server-preact` build clean with the new versions.