### PR TITLE
Allows passing input as a query param like other options from the demo app

### DIFF
--- a/examples/basic-host/src/index.tsx
+++ b/examples/basic-host/src/index.tsx
@@ -55,7 +55,9 @@ interface HostProps {
 type ToolCallEntry = ToolCallInfo & { id: number };
 let nextToolCallId = 0;
 
-// Parse URL query params for debugging: ?server=name&tool=name&call=true&theme=hide
+// Parse URL query params for debugging:
+//   ?server=name&tool=name&call=true&theme=hide
+//   &input={"question":"..."} (URL-encoded JSON to pre-fill tool arguments)
 function getQueryParams() {
   const params = new URLSearchParams(window.location.search);
   return {
@@ -63,6 +65,7 @@ function getQueryParams() {
     tool: params.get("tool"),
     call: params.get("call") === "true",
     hideThemeToggle: params.get("theme") === "hide",
+    input: params.get("input"),
   };
 }
 
@@ -123,6 +126,7 @@ function Host({ serversPromise }: HostProps) {
         addToolCall={(info) => setToolCalls([...toolCalls, { ...info, id: nextToolCallId++ }])}
         initialServer={queryParams.server}
         initialTool={queryParams.tool}
+        initialInput={queryParams.input}
         autoCall={queryParams.call}
       />
     </>
@@ -136,12 +140,13 @@ interface CallToolPanelProps {
   addToolCall: (info: ToolCallInfo) => void;
   initialServer?: string | null;
   initialTool?: string | null;
+  initialInput?: string | null;
   autoCall?: boolean;
 }
-function CallToolPanel({ serversPromise, addToolCall, initialServer, initialTool, autoCall }: CallToolPanelProps) {
+function CallToolPanel({ serversPromise, addToolCall, initialServer, initialTool, initialInput, autoCall }: CallToolPanelProps) {
   const [selectedServer, setSelectedServer] = useState<ServerInfo | null>(null);
   const [selectedTool, setSelectedTool] = useState("");
-  const [inputJson, setInputJson] = useState("{}");
+  const [inputJson, setInputJson] = useState(initialInput ?? "{}");
   const [hasAutoCalledRef] = useState({ called: false });
 
   // Filter out app-only tools, prioritize tools with UIs
@@ -174,8 +179,9 @@ function CallToolPanel({ serversPromise, addToolCall, initialServer, initialTool
       : visibleTools[0]?.name ?? "";
 
     setSelectedTool(targetTool);
-    // Set input JSON to tool defaults (if any)
-    setInputJson(getToolDefaults(server.tools.get(targetTool)));
+    if (!initialInput) {
+      setInputJson(getToolDefaults(server.tools.get(targetTool)));
+    }
   };
 
   const handleToolSelect = (toolName: string) => {
@@ -197,7 +203,8 @@ function CallToolPanel({ serversPromise, addToolCall, initialServer, initialTool
     const url = new URL(window.location.href);
     url.searchParams.set("server", server.name);
     url.searchParams.set("tool", tool);
-    url.searchParams.set("call", "true"); // Auto-call on refresh
+    url.searchParams.set("call", "true");
+    url.searchParams.set("input", inputJson);
     history.replaceState(null, "", url.toString());
   };
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add an input URL query parameter to the basic-host harness so developers can pre-fill tool arguments and bookmark specific tool calls that auto-fire on page load.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The basic-host harness already supports `?server=name&tool=name&call=true` to auto-select a server/tool and call it on load. However, the tool input always resets to the schema's default values, so developers have to manually paste arguments into the textarea every time they reload. This is especially tedious when iterating on MCP App cards that need specific arguments (e.g. start_analysis with a particular question). Adding `?input={"question":"..."}` lets developers bookmark a fully configured tool call URL that fires on load with the exact arguments they want with no manual steps needed and minimal maintenance burden for the very kind developers that are maintaining this.

I know you don't appreciate new examples being added for the maintenance costs. Hopefully this one is a small enough change to an existing example that it can pass the sniff test that this is just making life a little easier. 


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->


Tested locally against an MCP server running at localhost:3001. Verified:

- `?input={"question":"test"}` pre-fills the textarea with the provided JSON on load
- Combined with &call=true, the tool fires immediately with the provided input
- Without &input, behavior is unchanged (textarea initializes from schema defaults)
- Manually switching tools via the dropdown still resets input to that tool's defaults
- After calling a tool, the URL is updated via history.replaceState to include the current input, so refreshing replays the same call
- TypeScript compiles cleanly (tsc --noEmit)
- Prettier passes
- No tests for this area

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None. The input parameter is optional and defaults to null. When absent, all behavior is identical to before. The initialInput prop on CallToolPanel is optional with a null default.



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
