### PR TITLE
feat(probe): App-side bridge / host SEP-1865 conformance probe

### DIFF
--- a/build.bun.ts
+++ b/build.bun.ts
@@ -61,4 +61,8 @@ await Promise.all([
     outdir: "dist/src/server",
     external: PEER_EXTERNALS,
   }),
+  buildJs("src/probe/index.ts", {
+    outdir: "dist/src/probe",
+    external: PEER_EXTERNALS,
+  }),
 ]);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
       "types": "./dist/src/server/index.d.ts",
       "default": "./dist/src/server/index.js"
     },
+    "./probe": {
+      "types": "./dist/src/probe/index.d.ts",
+      "default": "./dist/src/probe/index.js"
+    },
     "./schema.json": "./dist/src/generated/schema.json"
   },
   "files": [

--- a/src/probe/assert.ts
+++ b/src/probe/assert.ts
@@ -1,0 +1,255 @@
+/**
+ * Pure assertion helpers that compare a {@link BridgeProbeSnapshot
+ * `BridgeProbeSnapshot`} against expected values. All helpers return
+ * `{ pass, checks[] }` and never throw — the caller decides whether a
+ * failure should warn, log, throw, or upload.
+ *
+ * The shape matches the per-check pattern used by mcpjam-learn's
+ * `assert-window-openai-surface` / `assert-host-capabilities` server tools
+ * so reports look identical across the two layers.
+ *
+ * @module probe
+ */
+
+import { BRIDGE_PRESETS, type BridgePresetName } from "./presets";
+import type {
+  BridgeIncomingName,
+  BridgeMethodName,
+  BridgeProbeSnapshot,
+} from "./types";
+
+export interface AssertionCheck {
+  rule: string;
+  expected: string;
+  actual: string;
+  pass: boolean;
+}
+
+export interface AssertionReport {
+  pass: boolean;
+  checks: AssertionCheck[];
+}
+
+export interface AssertBridgeMethodsOptions {
+  preset?: BridgePresetName;
+  expectedPresent?: BridgeMethodName[];
+  expectedAbsent?: BridgeMethodName[];
+  expectedNotifications?: BridgeIncomingName[];
+}
+
+/**
+ * Assert that probed methods + observed notifications match a named host
+ * preset and/or explicit per-method expectations. Preset values are merged
+ * with the explicit lists (explicit wins for duplicates).
+ */
+export function assertBridgeMethods(
+  snapshot: BridgeProbeSnapshot,
+  options: AssertBridgeMethodsOptions,
+): AssertionReport {
+  const preset = options.preset ? BRIDGE_PRESETS[options.preset] : undefined;
+  const expectedPresent = new Set<BridgeMethodName>([
+    ...(preset?.expectedPresent ?? []),
+    ...(options.expectedPresent ?? []),
+  ]);
+  const expectedAbsent = new Set<BridgeMethodName>([
+    ...(preset?.expectedAbsent ?? []),
+    ...(options.expectedAbsent ?? []),
+  ]);
+  const expectedNotifications = new Set<BridgeIncomingName>([
+    ...(preset?.expectedNotifications ?? []),
+    ...(options.expectedNotifications ?? []),
+  ]);
+
+  const checks: AssertionCheck[] = [];
+
+  for (const name of expectedPresent) {
+    const result = snapshot.methods[name];
+    const pass = result.status === "supported";
+    checks.push({
+      rule: `method:${name}`,
+      expected: "supported",
+      actual: result.status,
+      pass,
+    });
+  }
+  for (const name of expectedAbsent) {
+    const result = snapshot.methods[name];
+    const pass = result.status === "not-supported";
+    checks.push({
+      rule: `method:${name}`,
+      expected: "not-supported",
+      actual: result.status,
+      pass,
+    });
+  }
+  for (const name of expectedNotifications) {
+    const slot = snapshot.incoming[name];
+    const pass = slot?.observed === true;
+    checks.push({
+      rule: `notification:${name}`,
+      expected: "observed",
+      actual: slot?.observed ? "observed" : "not-observed",
+      pass,
+    });
+  }
+
+  return { pass: checks.every((c) => c.pass), checks };
+}
+
+/**
+ * Walk a dotted path on an object; returns `undefined` if any step is
+ * absent. Use to assert nested capability fields without bespoke validators.
+ */
+function getByDotPath(obj: unknown, path: string): unknown {
+  let current: unknown = obj;
+  for (const segment of path.split(".")) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+export interface AssertHostCapabilitiesOptions {
+  expectedPresent?: string[];
+  expectedAbsent?: string[];
+}
+
+/**
+ * Assert dot-path presence/absence against the snapshot's
+ * `hostCapabilities`. Useful paths: `openLinks`, `serverTools`, `logging`,
+ * `sandbox.csp`, `sandbox.permissions.clipboardWrite`, `updateModelContext`,
+ * `message`, `sampling.tools`.
+ */
+export function assertHostCapabilities(
+  snapshot: BridgeProbeSnapshot,
+  options: AssertHostCapabilitiesOptions,
+): AssertionReport {
+  const checks: AssertionCheck[] = [];
+  const caps = snapshot.hostCapabilities;
+  for (const path of options.expectedPresent ?? []) {
+    const value = getByDotPath(caps, path);
+    const present = value !== undefined;
+    checks.push({
+      rule: `hostCapabilities.${path}`,
+      expected: "present",
+      actual: present ? "present" : "absent",
+      pass: present,
+    });
+  }
+  for (const path of options.expectedAbsent ?? []) {
+    const value = getByDotPath(caps, path);
+    const present = value !== undefined;
+    checks.push({
+      rule: `hostCapabilities.${path}`,
+      expected: "absent",
+      actual: present ? "present" : "absent",
+      pass: !present,
+    });
+  }
+  return { pass: checks.every((c) => c.pass), checks };
+}
+
+export interface AssertHostContextOptions {
+  requirePresent?: string[];
+}
+
+const VALID_DISPLAY_MODES = new Set(["inline", "fullscreen", "pip"]);
+const VALID_THEMES = new Set(["light", "dark"]);
+const VALID_PLATFORMS = new Set(["web", "desktop", "mobile"]);
+
+/**
+ * Validate `hostContext` against the always-on SEP-1865 invariants
+ * (enum-typed fields, structural shapes). Pass `requirePresent` to add
+ * existence checks for optional fields you depend on (e.g. `theme`,
+ * `locale`, `containerDimensions`).
+ */
+export function assertHostContext(
+  snapshot: BridgeProbeSnapshot,
+  options: AssertHostContextOptions = {},
+): AssertionReport {
+  const checks: AssertionCheck[] = [];
+  const ctx = snapshot.hostContext ?? {};
+
+  const check = (
+    rule: string,
+    expected: string,
+    actual: string,
+    pass: boolean,
+  ) => checks.push({ rule, expected, actual, pass });
+
+  if (ctx.theme !== undefined) {
+    const pass = VALID_THEMES.has(ctx.theme);
+    check("hostContext.theme", "light|dark", String(ctx.theme), pass);
+  }
+  if (ctx.displayMode !== undefined) {
+    const pass = VALID_DISPLAY_MODES.has(ctx.displayMode);
+    check(
+      "hostContext.displayMode",
+      "inline|fullscreen|pip",
+      String(ctx.displayMode),
+      pass,
+    );
+  }
+  if (ctx.platform !== undefined) {
+    const pass = VALID_PLATFORMS.has(ctx.platform);
+    check(
+      "hostContext.platform",
+      "web|desktop|mobile",
+      String(ctx.platform),
+      pass,
+    );
+  }
+  if (ctx.availableDisplayModes !== undefined) {
+    const arr = ctx.availableDisplayModes;
+    const pass =
+      Array.isArray(arr) && arr.every((m) => VALID_DISPLAY_MODES.has(m));
+    check(
+      "hostContext.availableDisplayModes",
+      "array of inline|fullscreen|pip",
+      JSON.stringify(arr),
+      pass,
+    );
+  }
+  if (ctx.safeAreaInsets !== undefined) {
+    const s = ctx.safeAreaInsets;
+    const pass =
+      typeof s === "object" &&
+      s !== null &&
+      ["top", "right", "bottom", "left"].every(
+        (k) => typeof (s as Record<string, unknown>)[k] === "number",
+      );
+    check(
+      "hostContext.safeAreaInsets",
+      "{top,right,bottom,left: number}",
+      JSON.stringify(s),
+      pass,
+    );
+  }
+  if (ctx.deviceCapabilities !== undefined) {
+    const dc = ctx.deviceCapabilities as Record<string, unknown>;
+    for (const key of ["touch", "hover"]) {
+      if (dc[key] !== undefined) {
+        const pass = typeof dc[key] === "boolean";
+        check(
+          `hostContext.deviceCapabilities.${key}`,
+          "boolean",
+          String(dc[key]),
+          pass,
+        );
+      }
+    }
+  }
+
+  for (const path of options.requirePresent ?? []) {
+    const value = getByDotPath(ctx, path);
+    const present = value !== undefined;
+    check(
+      `hostContext.${path}`,
+      "present",
+      present ? "present" : "absent",
+      present,
+    );
+  }
+
+  return { pass: checks.every((c) => c.pass), checks };
+}

--- a/src/probe/capture.ts
+++ b/src/probe/capture.ts
@@ -1,0 +1,234 @@
+/**
+ * Run a SEP-1865 conformance probe against the current host's bridge from
+ * inside an App ({@link app!App `App`}). Records the host's claimed
+ * capabilities, observed lifecycle notifications, and the per-method probe
+ * matrix.
+ *
+ * @module probe
+ */
+
+import type { App } from "../app";
+import {
+  EmptyResultSchema,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
+import { ALL_BRIDGE_METHODS, BRIDGE_METHOD_PROBES } from "./methods";
+import type {
+  BridgeIncomingName,
+  BridgeMethodName,
+  BridgeMethodResult,
+  BridgeProbeOptions,
+  BridgeProbeSnapshot,
+} from "./types";
+
+const METHOD_NOT_FOUND = -32601;
+const DEFAULT_PROBE_TIMEOUT_MS = 3_000;
+
+const INCOMING_EVENT_MAP: ReadonlyArray<{
+  event:
+    | "toolinput"
+    | "toolinputpartial"
+    | "toolresult"
+    | "toolcancelled"
+    | "hostcontextchanged";
+  method: BridgeIncomingName;
+}> = [
+  { event: "toolinput", method: "ui/notifications/tool-input" },
+  { event: "toolinputpartial", method: "ui/notifications/tool-input-partial" },
+  { event: "toolresult", method: "ui/notifications/tool-result" },
+  { event: "toolcancelled", method: "ui/notifications/tool-cancelled" },
+  {
+    event: "hostcontextchanged",
+    method: "ui/notifications/host-context-changed",
+  },
+];
+
+/**
+ * Observer attached to an App that records incoming host → view messages
+ * over its lifetime. Attach before {@link app!App.connect `app.connect()`} so
+ * one-shot notifications like `tool-input` aren't missed.
+ */
+export class BridgeProbe {
+  private readonly incoming: Record<
+    BridgeIncomingName,
+    { observed: boolean; count: number; firstAt?: string }
+  >;
+  private readonly errors: BridgeProbeSnapshot["errors"] = [];
+
+  constructor(private readonly app: App) {
+    this.incoming = Object.fromEntries(
+      (
+        [
+          "ui/notifications/tool-input",
+          "ui/notifications/tool-input-partial",
+          "ui/notifications/tool-result",
+          "ui/notifications/tool-cancelled",
+          "ui/notifications/host-context-changed",
+          "ui/resource-teardown",
+        ] as BridgeIncomingName[]
+      ).map((m) => [m, { observed: false, count: 0 }]),
+    ) as BridgeProbeSnapshot["incoming"];
+
+    for (const { event, method } of INCOMING_EVENT_MAP) {
+      app.addEventListener(event, () => this.record(method));
+    }
+
+    // Chain onto onteardown so we observe the request without breaking any
+    // teardown handler the consumer installs. If they install one *after*
+    // attach, the App's setter will replace ours — accepted tradeoff (the
+    // probe only needs the first occurrence anyway).
+    const existing = app.onteardown;
+    app.onteardown = async (params, extra) => {
+      this.record("ui/resource-teardown");
+      if (existing) return existing(params, extra);
+      return {};
+    };
+  }
+
+  private record(method: BridgeIncomingName): void {
+    const slot = this.incoming[method];
+    slot.count++;
+    if (!slot.observed) {
+      slot.observed = true;
+      slot.firstAt = new Date().toISOString();
+    }
+  }
+
+  /**
+   * Probe each requested method and return a full snapshot. Safe to call
+   * multiple times; later calls return a fresh snapshot reflecting any new
+   * notifications observed since the previous one.
+   */
+  async capture(
+    options: BridgeProbeOptions = {},
+  ): Promise<BridgeProbeSnapshot> {
+    const {
+      activeProbes = true,
+      probeTimeoutMs = DEFAULT_PROBE_TIMEOUT_MS,
+      methods = ALL_BRIDGE_METHODS,
+    } = options;
+
+    const results = Object.fromEntries(
+      ALL_BRIDGE_METHODS.map((m) => [
+        m,
+        { status: "untested", reason: "not requested" } as BridgeMethodResult,
+      ]),
+    ) as Record<BridgeMethodName, BridgeMethodResult>;
+
+    if (activeProbes) {
+      for (const name of methods) {
+        results[name] = await this.probeMethod(name, probeTimeoutMs);
+      }
+    } else {
+      for (const name of methods) {
+        results[name] = {
+          status: "untested",
+          reason: "activeProbes disabled",
+        };
+      }
+    }
+
+    return {
+      schemaVersion: 1,
+      capturedAt: new Date().toISOString(),
+      hostInfo: this.app.getHostVersion(),
+      hostCapabilities: this.app.getHostCapabilities(),
+      hostContext: this.app.getHostContext(),
+      methods: results,
+      // Clone so callers can compare across captures without sharing state.
+      incoming: Object.fromEntries(
+        Object.entries(this.incoming).map(([k, v]) => [k, { ...v }]),
+      ) as BridgeProbeSnapshot["incoming"],
+      errors: [...this.errors],
+    };
+  }
+
+  private async probeMethod(
+    name: BridgeMethodName,
+    timeoutMs: number,
+  ): Promise<BridgeMethodResult> {
+    const probe = BRIDGE_METHOD_PROBES[name];
+    // Skip sampling when the host hasn't advertised it — the App SDK would
+    // throw client-side under strict mode, and we have no way to disambiguate
+    // a host that hides the capability from one that doesn't implement it.
+    if (
+      name === "sampling/createMessage" &&
+      !this.app.getHostCapabilities()?.sampling
+    ) {
+      return {
+        status: "untested",
+        reason: "host did not advertise sampling capability",
+      };
+    }
+    try {
+      // App extends Protocol; request() is public. Cast the typed request
+      // through unknown because BridgeMethodName is broader than AppRequest's
+      // union (e.g. covers ping which Protocol routes specially).
+      await (
+        this.app as unknown as {
+          request: (
+            req: { method: string; params?: unknown },
+            schema: typeof EmptyResultSchema,
+            opts?: { timeout?: number },
+          ) => Promise<unknown>;
+        }
+      ).request(
+        { method: probe.method, params: probe.params },
+        EmptyResultSchema,
+        { timeout: timeoutMs },
+      );
+      return { status: "supported", via: "success" };
+    } catch (e) {
+      if (e instanceof McpError) {
+        if (e.code === METHOD_NOT_FOUND) {
+          return { status: "not-supported", errorCode: METHOD_NOT_FOUND };
+        }
+        return {
+          status: "supported",
+          via: "non-mnf-error",
+          errorCode: e.code,
+        };
+      }
+      const message = e instanceof Error ? e.message : String(e);
+      this.errors.push({ where: `probeMethod:${name}`, message });
+      return { status: "errored", message };
+    }
+  }
+}
+
+/**
+ * Attach a {@link BridgeProbe `BridgeProbe`} to an App **before** calling
+ * `app.connect()` so it can observe one-shot notifications (`tool-input`,
+ * `tool-result`, etc.) that the host fires once at the start of the
+ * lifecycle.
+ *
+ * @example
+ * ```ts
+ * const app = new App({ name: "My App", version: "1.0.0" });
+ * const probe = attachBridgeProbe(app);
+ * await app.connect(transport);
+ * // … app lifecycle proceeds normally …
+ * const snapshot = await probe.capture({ activeProbes: true });
+ * console.table(snapshot.methods);
+ * ```
+ */
+export function attachBridgeProbe(app: App): BridgeProbe {
+  return new BridgeProbe(app);
+}
+
+/**
+ * Convenience wrapper for one-shot probing of an already-connected App.
+ *
+ * Skips early notifications that the host may have already fired before this
+ * call (use {@link attachBridgeProbe `attachBridgeProbe`} before
+ * `app.connect()` to capture those). Still records claimed capabilities and
+ * any notifications that fire from this moment forward, and runs the active
+ * method probes.
+ */
+export async function captureBridgeSurface(
+  app: App,
+  options?: BridgeProbeOptions,
+): Promise<BridgeProbeSnapshot> {
+  const probe = new BridgeProbe(app);
+  return probe.capture(options);
+}

--- a/src/probe/index.ts
+++ b/src/probe/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Bridge / host conformance probe for the MCP Apps SDK.
+ *
+ * Drop-in tooling that lets any App snapshot which bridge methods +
+ * notifications its current host actually supports — both via the host's
+ * declared `hostCapabilities` and via active per-method probes that
+ * distinguish `-32601 Method not found` from any other response.
+ *
+ * @module probe
+ *
+ * @example
+ * ```ts
+ * import { App } from "@modelcontextprotocol/ext-apps";
+ * import {
+ *   attachBridgeProbe,
+ *   assertBridgeMethods,
+ * } from "@modelcontextprotocol/ext-apps/probe";
+ *
+ * const app = new App({ name: "My App", version: "1.0.0" });
+ * const probe = attachBridgeProbe(app); // BEFORE connect, to catch one-shot notifs
+ * await app.connect(transport);
+ * // … app lifecycle proceeds …
+ * const snapshot = await probe.capture({ activeProbes: true });
+ * const report = assertBridgeMethods(snapshot, { preset: "chatgpt" });
+ * if (!report.pass) console.warn("Bridge conformance failed:", report.checks);
+ * ```
+ */
+
+export {
+  attachBridgeProbe,
+  captureBridgeSurface,
+  BridgeProbe,
+} from "./capture";
+export {
+  assertBridgeMethods,
+  assertHostCapabilities,
+  assertHostContext,
+  type AssertBridgeMethodsOptions,
+  type AssertHostCapabilitiesOptions,
+  type AssertHostContextOptions,
+  type AssertionCheck,
+  type AssertionReport,
+} from "./assert";
+export { BRIDGE_PRESETS } from "./presets";
+export type { BridgePresetName, BridgePreset } from "./presets";
+export {
+  ALL_BRIDGE_METHODS,
+  BRIDGE_METHOD_PROBES,
+  type BridgeMethodProbe,
+} from "./methods";
+export type {
+  BridgeIncomingName,
+  BridgeMethodName,
+  BridgeMethodResult,
+  BridgeProbeOptions,
+  BridgeProbeSnapshot,
+} from "./types";

--- a/src/probe/methods.ts
+++ b/src/probe/methods.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-method probe definitions. Each entry specifies the JSON-RPC method,
+ * a benign payload that any conforming host should at minimum *understand*
+ * (i.e. not return `-32601 Method not found`), and notes about likely side
+ * effects.
+ *
+ * Hosts that reject the call for unrelated reasons (`-32602`, `-32000`,
+ * etc.) still count as "supports the method" — the probe only treats
+ * `MethodNotFound` as a hard absence signal.
+ */
+
+import type { BridgeMethodName } from "./types";
+
+export interface BridgeMethodProbe {
+  method: BridgeMethodName;
+  params: unknown;
+  /** True if this probe may trigger a user-visible dialog or chat insertion. */
+  hasSideEffects: boolean;
+}
+
+/**
+ * Sentinel resource URI used for `resources/read` probes. Hosts that proxy
+ * to the MCP server should return `-32602` / `-32000` (resource not found)
+ * rather than `-32601`, proving the route exists.
+ */
+const SENTINEL_RESOURCE_URI = "probe://bridge-conformance/sentinel";
+
+/** Sentinel tool name used for `tools/call` probes. */
+const SENTINEL_TOOL_NAME = "__probe_bridge_conformance_sentinel__";
+
+export const BRIDGE_METHOD_PROBES: Readonly<
+  Record<BridgeMethodName, BridgeMethodProbe>
+> = {
+  ping: { method: "ping", params: {}, hasSideEffects: false },
+  "tools/list": { method: "tools/list", params: {}, hasSideEffects: false },
+  "tools/call": {
+    method: "tools/call",
+    params: { name: SENTINEL_TOOL_NAME, arguments: {} },
+    hasSideEffects: false,
+  },
+  "resources/list": {
+    method: "resources/list",
+    params: {},
+    hasSideEffects: false,
+  },
+  "resources/read": {
+    method: "resources/read",
+    params: { uri: SENTINEL_RESOURCE_URI },
+    hasSideEffects: false,
+  },
+  "prompts/list": { method: "prompts/list", params: {}, hasSideEffects: false },
+  "sampling/createMessage": {
+    method: "sampling/createMessage",
+    params: {
+      messages: [{ role: "user", content: { type: "text", text: "probe" } }],
+      maxTokens: 1,
+    },
+    hasSideEffects: true,
+  },
+  "ui/open-link": {
+    method: "ui/open-link",
+    params: { url: "about:blank" },
+    hasSideEffects: true,
+  },
+  "ui/download-file": {
+    method: "ui/download-file",
+    params: {
+      contents: [
+        {
+          type: "resource",
+          resource: {
+            uri: "file:///probe.txt",
+            mimeType: "text/plain",
+            text: "probe",
+          },
+        },
+      ],
+    },
+    hasSideEffects: true,
+  },
+  "ui/message": {
+    method: "ui/message",
+    params: {
+      role: "user",
+      content: { type: "text", text: "" },
+    },
+    hasSideEffects: true,
+  },
+  "ui/request-display-mode": {
+    method: "ui/request-display-mode",
+    params: { mode: "inline" },
+    hasSideEffects: true,
+  },
+  "ui/update-model-context": {
+    method: "ui/update-model-context",
+    params: { content: [] },
+    hasSideEffects: true,
+  },
+};
+
+export const ALL_BRIDGE_METHODS: readonly BridgeMethodName[] = Object.keys(
+  BRIDGE_METHOD_PROBES,
+) as BridgeMethodName[];

--- a/src/probe/presets.ts
+++ b/src/probe/presets.ts
@@ -1,0 +1,102 @@
+/**
+ * Named host presets that describe an expected bridge surface. Values are
+ * seeded from public docs and observations against running hosts at the
+ * time of writing; treat them as starting points and refine after a fresh
+ * cross-host probe run.
+ *
+ * @module probe
+ */
+
+import type { BridgeIncomingName, BridgeMethodName } from "./types";
+
+export interface BridgePreset {
+  /** Methods the host is expected to *support* (responds with anything other than -32601). */
+  expectedPresent: BridgeMethodName[];
+  /** Methods the host is expected to *not* implement (responds with -32601). */
+  expectedAbsent: BridgeMethodName[];
+  /** Notifications/requests we expect the host to emit during a normal lifecycle. */
+  expectedNotifications: BridgeIncomingName[];
+}
+
+/**
+ * Spec floor — every conformant SEP-1865 host should at least answer these.
+ * `ui/initialize` is handled by the App SDK itself so it's not probed.
+ */
+const SPEC_MINIMAL: BridgePreset = {
+  expectedPresent: ["ping"],
+  expectedAbsent: [],
+  expectedNotifications: ["ui/notifications/tool-input"],
+};
+
+const CHATGPT: BridgePreset = {
+  expectedPresent: [
+    "ping",
+    "tools/list",
+    "tools/call",
+    "resources/read",
+    "ui/open-link",
+    "ui/message",
+    "ui/request-display-mode",
+    "ui/update-model-context",
+  ],
+  expectedAbsent: [],
+  expectedNotifications: [
+    "ui/notifications/tool-input",
+    "ui/notifications/tool-result",
+    "ui/notifications/host-context-changed",
+  ],
+};
+
+const CLAUDE_DESKTOP: BridgePreset = {
+  expectedPresent: [
+    "ping",
+    "tools/list",
+    "tools/call",
+    "resources/read",
+    "ui/open-link",
+    "ui/message",
+  ],
+  expectedAbsent: [],
+  expectedNotifications: [
+    "ui/notifications/tool-input",
+    "ui/notifications/tool-result",
+  ],
+};
+
+const COPILOT: BridgePreset = {
+  expectedPresent: ["ping", "tools/call", "ui/open-link", "ui/message"],
+  expectedAbsent: ["ui/download-file"],
+  expectedNotifications: [
+    "ui/notifications/tool-input",
+    "ui/notifications/tool-result",
+  ],
+};
+
+const MCPJAM_INSPECTOR: BridgePreset = {
+  expectedPresent: [
+    "ping",
+    "tools/list",
+    "tools/call",
+    "resources/list",
+    "resources/read",
+    "ui/open-link",
+    "ui/message",
+    "ui/update-model-context",
+  ],
+  expectedAbsent: [],
+  expectedNotifications: [
+    "ui/notifications/tool-input",
+    "ui/notifications/tool-result",
+  ],
+};
+
+// TODO: refine after first cross-host run with the probe enabled.
+export const BRIDGE_PRESETS = {
+  "spec-minimal": SPEC_MINIMAL,
+  chatgpt: CHATGPT,
+  "claude-desktop": CLAUDE_DESKTOP,
+  copilot: COPILOT,
+  "mcpjam-inspector": MCPJAM_INSPECTOR,
+} as const satisfies Record<string, BridgePreset>;
+
+export type BridgePresetName = keyof typeof BRIDGE_PRESETS;

--- a/src/probe/probe.test.ts
+++ b/src/probe/probe.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+
+import { App } from "../app";
+import { AppBridge, type McpUiHostCapabilities } from "../app-bridge";
+
+import {
+  attachBridgeProbe,
+  captureBridgeSurface,
+  assertBridgeMethods,
+  assertHostCapabilities,
+  assertHostContext,
+} from "./index";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function createMockClient(): Pick<
+  Client,
+  "getServerCapabilities" | "request" | "notification"
+> {
+  return {
+    getServerCapabilities: () => ({}),
+    // AppBridge proxies tools/resources/prompts through the MCP client.
+    // Return -32601 for any client call we don't explicitly handle so the
+    // bridge surfaces "method not supported".
+    request: async () => {
+      throw new McpError(
+        ErrorCode.MethodNotFound,
+        "mock client: not implemented",
+      );
+    },
+    notification: async () => {},
+  };
+}
+
+const hostInfo = { name: "TestHost", version: "1.0.0" };
+const appInfo = { name: "TestApp", version: "1.0.0" };
+
+describe("bridge probe", () => {
+  let app: App;
+  let bridge: AppBridge;
+  let appTransport: InMemoryTransport;
+  let bridgeTransport: InMemoryTransport;
+
+  beforeEach(() => {
+    [appTransport, bridgeTransport] = InMemoryTransport.createLinkedPair();
+    app = new App(appInfo, {}, { autoResize: false });
+  });
+
+  afterEach(async () => {
+    await appTransport.close();
+    await bridgeTransport.close();
+  });
+
+  it("records hostInfo / hostCapabilities / hostContext from initialize", async () => {
+    const hostCaps: McpUiHostCapabilities = {
+      openLinks: {},
+      serverTools: {},
+      logging: {},
+    };
+    bridge = new AppBridge(createMockClient() as Client, hostInfo, hostCaps, {
+      hostContext: { theme: "dark", locale: "en-US" },
+    });
+    await bridge.connect(bridgeTransport);
+    await app.connect(appTransport);
+
+    const snapshot = await captureBridgeSurface(app, { activeProbes: false });
+    expect(snapshot.hostInfo).toEqual(hostInfo);
+    expect(snapshot.hostCapabilities).toEqual(hostCaps);
+    expect(snapshot.hostContext?.theme).toBe("dark");
+    expect(snapshot.hostContext?.locale).toBe("en-US");
+  });
+
+  it("observes one-shot notifications when attached before connect", async () => {
+    bridge = new AppBridge(createMockClient() as Client, hostInfo, {});
+    await bridge.connect(bridgeTransport);
+
+    // Attach BEFORE connect — required for tool-input/result coverage.
+    const probe = attachBridgeProbe(app);
+    await app.connect(appTransport);
+
+    await bridge.sendToolInput({ arguments: { q: "hello" } });
+    await bridge.sendToolResult({
+      content: [{ type: "text", text: "ok" }],
+    });
+    bridge.setHostContext({ theme: "light" });
+    await flush();
+
+    const snapshot = await probe.capture({ activeProbes: false });
+    expect(snapshot.incoming["ui/notifications/tool-input"].observed).toBe(
+      true,
+    );
+    expect(snapshot.incoming["ui/notifications/tool-input"].count).toBe(1);
+    expect(snapshot.incoming["ui/notifications/tool-result"].observed).toBe(
+      true,
+    );
+    expect(
+      snapshot.incoming["ui/notifications/host-context-changed"].observed,
+    ).toBe(true);
+    expect(snapshot.incoming["ui/notifications/tool-cancelled"].observed).toBe(
+      false,
+    );
+  });
+
+  it("does not clobber user-installed on* handlers", async () => {
+    bridge = new AppBridge(createMockClient() as Client, hostInfo, {});
+    await bridge.connect(bridgeTransport);
+
+    const userToolInputs: unknown[] = [];
+    app.ontoolinput = (params) => userToolInputs.push(params.arguments);
+    const userHostCtx: unknown[] = [];
+    app.onhostcontextchanged = (params) => userHostCtx.push(params);
+
+    attachBridgeProbe(app);
+    await app.connect(appTransport);
+
+    await bridge.sendToolInput({ arguments: { z: 1 } });
+    bridge.setHostContext({ theme: "dark" });
+    await flush();
+
+    expect(userToolInputs).toEqual([{ z: 1 }]);
+    expect(userHostCtx).toEqual([{ theme: "dark" }]);
+  });
+
+  it("classifies methods as not-supported when host returns -32601", async () => {
+    // Bridge with null client returns -32601 for proxied calls (no handlers
+    // registered for resources/tools/prompts/sampling). ui/* methods backed
+    // by replaceRequestHandler in AppBridge respond normally.
+    bridge = new AppBridge(null, hostInfo, {
+      openLinks: {},
+      updateModelContext: {},
+      message: {},
+    });
+    await bridge.connect(bridgeTransport);
+
+    // Register ui/open-link as a no-op success.
+    bridge.onopenlink = async () => ({});
+    bridge.onmessage = async () => ({});
+    bridge.onupdatemodelcontext = async () => ({});
+
+    await app.connect(appTransport);
+    const snapshot = await captureBridgeSurface(app, {
+      activeProbes: true,
+      probeTimeoutMs: 1_000,
+    });
+
+    expect(snapshot.methods["ui/open-link"].status).toBe("supported");
+    expect(snapshot.methods["ui/message"].status).toBe("supported");
+    expect(snapshot.methods["ui/update-model-context"].status).toBe(
+      "supported",
+    );
+    // No tools/resources/prompts handlers → host returns -32601.
+    expect(snapshot.methods["tools/list"].status).toBe("not-supported");
+    expect(snapshot.methods["resources/read"].status).toBe("not-supported");
+    expect(snapshot.methods["prompts/list"].status).toBe("not-supported");
+    // No sampling capability advertised → marked untested, not probed.
+    expect(snapshot.methods["sampling/createMessage"].status).toBe("untested");
+  });
+
+  it("treats non-MNF errors as supported", async () => {
+    bridge = new AppBridge(null, hostInfo, { openLinks: {} });
+    await bridge.connect(bridgeTransport);
+    bridge.onopenlink = async () => {
+      throw new McpError(ErrorCode.InvalidParams, "bad url");
+    };
+    await app.connect(appTransport);
+
+    const snapshot = await captureBridgeSurface(app, { activeProbes: true });
+    const result = snapshot.methods["ui/open-link"];
+    expect(result.status).toBe("supported");
+    if (result.status === "supported") {
+      expect(result.via).toBe("non-mnf-error");
+      expect(result.errorCode).toBe(ErrorCode.InvalidParams);
+    }
+  });
+
+  describe("assertions", () => {
+    beforeEach(async () => {
+      bridge = new AppBridge(null, hostInfo, {
+        openLinks: {},
+        serverTools: {},
+        logging: {},
+      });
+      bridge.onopenlink = async () => ({});
+      await bridge.connect(bridgeTransport);
+      await app.connect(appTransport);
+    });
+
+    it("assertHostCapabilities passes for present paths", async () => {
+      const snap = await captureBridgeSurface(app, { activeProbes: false });
+      const report = assertHostCapabilities(snap, {
+        expectedPresent: ["openLinks", "serverTools", "logging"],
+        expectedAbsent: ["downloadFile", "sampling"],
+      });
+      expect(report.pass).toBe(true);
+      expect(report.checks.every((c) => c.pass)).toBe(true);
+    });
+
+    it("assertHostCapabilities fails when an expected path is missing", async () => {
+      const snap = await captureBridgeSurface(app, { activeProbes: false });
+      const report = assertHostCapabilities(snap, {
+        expectedPresent: ["downloadFile"],
+      });
+      expect(report.pass).toBe(false);
+    });
+
+    it("assertHostContext validates enum-typed fields", async () => {
+      // Bridge.setHostContext doesn't surface invalid enums easily, so test
+      // the validator directly on a synthetic snapshot.
+      const synthetic = {
+        schemaVersion: 1 as const,
+        capturedAt: new Date().toISOString(),
+        hostContext: {
+          theme: "dark" as const,
+          displayMode: "inline" as const,
+          platform: "web" as const,
+          availableDisplayModes: ["inline", "fullscreen"] as Array<
+            "inline" | "fullscreen" | "pip"
+          >,
+        },
+        methods: {} as never,
+        incoming: {} as never,
+        errors: [],
+      };
+      const report = assertHostContext(synthetic);
+      expect(report.pass).toBe(true);
+    });
+
+    it("assertBridgeMethods works against an explicit expected list", async () => {
+      const snap = await captureBridgeSurface(app, { activeProbes: true });
+      const report = assertBridgeMethods(snap, {
+        expectedPresent: ["ui/open-link"],
+        expectedAbsent: ["tools/list"],
+      });
+      expect(report.pass).toBe(true);
+    });
+  });
+});

--- a/src/probe/types.ts
+++ b/src/probe/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Snapshot types for the bridge / host conformance probe.
+ *
+ * The probe runs from inside an App ({@link app!App `App`}) and records what
+ * the surrounding host's bridge actually supports — claimed capabilities,
+ * observed lifecycle notifications, and per-method active probes. The shape
+ * mirrors the `windowOpenai` matrix pattern from mcpjam-learn so existing
+ * tooling and presets transfer over.
+ *
+ * @module probe
+ */
+
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
+import type { McpUiHostCapabilities, McpUiHostContext } from "../spec.types";
+
+/**
+ * Result of probing a single bridge method (View → Host).
+ *
+ * `not-supported` is asserted only when the host returned a JSON-RPC
+ * `-32601 Method not found`. Any other JSON-RPC error (`-32602 Invalid
+ * params`, `-32000 Denied`, etc.) counts as `supported` because the host
+ * understood the method even though it refused this particular call.
+ */
+export type BridgeMethodResult =
+  | {
+      status: "supported";
+      via: "success" | "non-mnf-error";
+      errorCode?: number;
+    }
+  | { status: "not-supported"; errorCode: -32601 }
+  | { status: "errored"; message: string }
+  | { status: "untested"; reason: string };
+
+/** View → Host methods we know how to probe. */
+export type BridgeMethodName =
+  | "ping"
+  | "tools/list"
+  | "tools/call"
+  | "resources/list"
+  | "resources/read"
+  | "prompts/list"
+  | "sampling/createMessage"
+  | "ui/open-link"
+  | "ui/download-file"
+  | "ui/message"
+  | "ui/request-display-mode"
+  | "ui/update-model-context";
+
+/** Host → View notifications and requests we observe. */
+export type BridgeIncomingName =
+  | "ui/notifications/tool-input"
+  | "ui/notifications/tool-input-partial"
+  | "ui/notifications/tool-result"
+  | "ui/notifications/tool-cancelled"
+  | "ui/notifications/host-context-changed"
+  | "ui/resource-teardown";
+
+export interface BridgeProbeOptions {
+  /**
+   * Send active method probes to the host. Each method is probed with a
+   * benign payload; hosts that gate on user consent may show a denial dialog
+   * for some of them (notably `ui/open-link`, `ui/message`,
+   * `ui/download-file`). Defaults to `true`.
+   */
+  activeProbes?: boolean;
+  /** Per-probe timeout in ms. Default 3000. */
+  probeTimeoutMs?: number;
+  /** Subset of methods to probe; if omitted, probes the full {@link BridgeMethodName} set. */
+  methods?: ReadonlyArray<BridgeMethodName>;
+}
+
+export interface BridgeProbeSnapshot {
+  schemaVersion: 1;
+  capturedAt: string;
+  hostInfo?: Implementation;
+  /** Raw capabilities as the host advertised them in `ui/initialize`. */
+  hostCapabilities?: McpUiHostCapabilities;
+  /** Last known host context at snapshot time. */
+  hostContext?: McpUiHostContext;
+  /** Per-method probe outcomes. Unprobed methods appear as `untested`. */
+  methods: Record<BridgeMethodName, BridgeMethodResult>;
+  /**
+   * Host → View messages observed by the probe. `observed` is true for any
+   * message seen since the probe was attached (pre-connect for full coverage,
+   * post-connect captures whatever is still firing).
+   */
+  incoming: Record<
+    BridgeIncomingName,
+    { observed: boolean; count: number; firstAt?: string }
+  >;
+  errors: Array<{ where: string; message: string }>;
+}


### PR DESCRIPTION
## Summary

Adds `@modelcontextprotocol/ext-apps/probe` — an optional, App-side module that lets any view snapshot which bridge methods and notifications the host actually supports, beyond what `App.getHostCapabilities()` *claims*. Hosts vary in which optional MCP Apps methods/notifications they actually implement, and capability claims can diverge from reality — this probe library makes that surface readable and assertable.

## What it does

- **`attachBridgeProbe(app)`** (call **before** `app.connect()`): observes the full Host → View notification timeline (`tool-input`, `tool-input-partial`, `tool-result`, `tool-cancelled`, `host-context-changed`) plus the `ui/resource-teardown` request — without clobbering any handlers the consumer installs. Chains onto `onteardown` and uses `addEventListener` for notifications.
- **`probe.capture({ activeProbes: true })`**: issues each known View → Host method (`ping`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `sampling/createMessage`, `ui/open-link`, `ui/download-file`, `ui/message`, `ui/request-display-mode`, `ui/update-model-context`) with a benign payload and classifies the response:
  - `-32601 Method not found` → `not-supported`
  - any other JSON-RPC error → `supported (non-mnf-error)` — host understood, refused this call
  - success → `supported`
- **Pure assertion helpers** (`assertBridgeMethods`, `assertHostCapabilities`, `assertHostContext`) return `{ pass, checks[] }`. No test-runner coupling; callers decide whether failure logs/throws/uploads.
- **Named host presets** (`spec-minimal`, `chatgpt`, `claude-desktop`, `copilot`, `mcpjam-inspector`) for one-line conformance checks. Seeded from public docs; marked for refinement after cross-host runs.

## Usage

```ts
import { App } from \"@modelcontextprotocol/ext-apps\";
import {
  attachBridgeProbe,
  assertBridgeMethods,
} from \"@modelcontextprotocol/ext-apps/probe\";

const app = new App({ name: \"My App\", version: \"1.0.0\" });
const probe = attachBridgeProbe(app); // before connect — catches one-shot notifs
await app.connect(transport);
// … normal app lifecycle …
const snapshot = await probe.capture({ activeProbes: true });
console.table(snapshot.methods);

const report = assertBridgeMethods(snapshot, { preset: \"chatgpt\" });
if (!report.pass) console.warn(\"Bridge conformance failed:\", report.checks);
```

## Wiring

- New \`./probe\` package export entry in \`package.json\`.
- New entry in \`build.bun.ts\` so \`dist/src/probe/{index.js,*.d.ts}\` ship (≈7.5KB minified ESM).
- No new runtime dependencies; only uses \`@modelcontextprotocol/sdk\` types already needed by \`App\`.

## Tests

- 9 new unit tests in \`src/probe/probe.test.ts\` using \`InMemoryTransport\` + a real \`AppBridge\` fixture covering:
  - Claimed capability / hostInfo / hostContext capture
  - One-shot notification observation when attached pre-connect
  - No-clobber of user-installed \`on*\` handlers
  - \`-32601\` → \`not-supported\` classification
  - Non-MNF errors → \`supported (non-mnf-error)\`
  - All three assertion helpers (methods, host capabilities, host context)
- Existing 284 ext-apps tests pass unchanged.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`bun test src\` — 293 pass, 0 fail
- [x] \`npm run build\` produces \`dist/src/probe/index.js\` and \`.d.ts\` files
- [ ] Cross-host smoke: drop probe into a real App in ChatGPT, Claude Desktop, M365 Copilot, MCPJam Inspector and refine preset definitions based on observed differences

🤖 Generated with [Claude Code](https://claude.com/claude-code)