### PR TITLE
Add tool result _meta in tool response and access in the ui

### DIFF
--- a/examples/quickstart/mcp-app.html
+++ b/examples/quickstart/mcp-app.html
@@ -8,6 +8,9 @@
     <p>
       <strong>Server Time:</strong> <code id="server-time">Loading...</code>
     </p>
+    <p>
+      <strong>Tool Meta Source:</strong> <code id="tool-meta-source">[none]</code>
+    </p>
     <button id="get-time-btn">Get Server Time</button>
     <script type="module" src="/src/mcp-app.ts"></script>
   </body>

--- a/examples/quickstart/server.ts
+++ b/examples/quickstart/server.ts
@@ -35,7 +35,14 @@ export function createServer(): McpServer {
     },
     async () => {
       const time = new Date().toISOString();
-      return { content: [{ type: "text", text: time }] };
+      return {
+        content: [{ type: "text", text: time }],
+        _meta: {
+          timestamp: time,
+          source: "quickstart-server",
+          debugToken: "quickstart-meta-debug",
+        },
+      };
     },
   );
 

--- a/examples/quickstart/src/mcp-app.ts
+++ b/examples/quickstart/src/mcp-app.ts
@@ -2,24 +2,34 @@ import { App } from "@modelcontextprotocol/ext-apps";
 
 // Get element references
 const serverTimeEl = document.getElementById("server-time")!;
+const toolMetaSourceEl = document.getElementById("tool-meta-source")!;
 const getTimeBtn = document.getElementById("get-time-btn")!;
 
 // Create app instance
 const app = new App({ name: "Get Time App", version: "1.0.0" });
 
+function extractMetaSource(result: unknown): string {
+  const meta = (result as { _meta?: { source?: unknown } })._meta;
+  return typeof meta?.source === "string" ? meta.source : "[missing]";
+}
+
 // Handle tool results from the server. Set before `app.connect()` to avoid
 // missing the initial tool result.
 app.ontoolresult = (result) => {
+  console.info("tool-result _meta:", (result as { _meta?: unknown })._meta);
   const time = result.content?.find((c) => c.type === "text")?.text;
   serverTimeEl.textContent = time ?? "[ERROR]";
+  toolMetaSourceEl.textContent = extractMetaSource(result);
 };
 
 // Wire up button click
 getTimeBtn.addEventListener("click", async () => {
   // `app.callServerTool()` lets the UI request fresh data from the server
   const result = await app.callServerTool({ name: "get-time", arguments: {} });
+  console.info("callServerTool _meta:", (result as { _meta?: unknown })._meta);
   const time = result.content?.find((c) => c.type === "text")?.text;
   serverTimeEl.textContent = time ?? "[ERROR]";
+  toolMetaSourceEl.textContent = extractMetaSource(result);
 });
 
 // Connect to host


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Include _meta in tool output and access it from the ui
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
While [the docs](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx#2-tool-result-via-uinotificationstool-result-notification) specify that tooloutput _meta is forwarded to the ui and hidden from the model some providers including the basic host in this repo fail to make the _meta available to the ui. This PR will help demonstrate the functionality and can help others troubleshoot this. 
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Claude.ai does forward tool output meta to the ui however chatgpt does not and there are [ongoing discussions](https://community.openai.com/t/mcp-apps-in-chatgpt-are-fundamentally-broken-2-critical-bugs/1377697/21) in developer communities for how to troubleshoot this 
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
