### PR TITLE
chore: bump ext-apps to 1.7.3

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -112,6 +112,7 @@ jobs:
           - cohort-heatmap-server
           - customer-segmentation-server
           - debug-server
+          - lazy-auth-server
           - map-server
           - pdf-server
           - scenario-modeler-server

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
             ./examples/cohort-heatmap-server \
             ./examples/customer-segmentation-server \
             ./examples/debug-server \
+            ./examples/lazy-auth-server \
             ./examples/map-server \
             ./examples/pdf-server \
             ./examples/scenario-modeler-server \

--- a/examples/basic-host/package.json
+++ b/examples/basic-host/package.json
@@ -1,7 +1,7 @@
 {
   "homepage": "https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/basic-host",
   "name": "@modelcontextprotocol/ext-apps-basic-host",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && concurrently \"cross-env INPUT=index.html vite build\" \"cross-env INPUT=sandbox.html vite build\"",
@@ -11,7 +11,7 @@
     "dev": "cross-env NODE_ENV=development concurrently \"npm run watch\" \"npm run serve\""
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/examples/basic-server-preact/package.json
+++ b/examples/basic-server-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-preact",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Basic MCP App Server example using Preact",
   "repository": {
@@ -24,7 +24,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/basic-server-react/package.json
+++ b/examples/basic-server-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-react",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Basic MCP App Server example using React",
   "repository": {
@@ -34,7 +34,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/basic-server-solid/package.json
+++ b/examples/basic-server-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-solid",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Basic MCP App Server example using Solid",
   "repository": {
@@ -24,7 +24,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/basic-server-svelte/package.json
+++ b/examples/basic-server-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-svelte",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Basic MCP App Server example using Svelte",
   "repository": {
@@ -24,7 +24,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/basic-server-vanillajs/package.json
+++ b/examples/basic-server-vanillajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-vanillajs",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Basic MCP App Server example using vanilla JavaScript",
   "repository": {
@@ -24,7 +24,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/basic-server-vue/package.json
+++ b/examples/basic-server-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-basic-vue",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Basic MCP App Server example using Vue",
   "repository": {
@@ -24,7 +24,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/budget-allocator-server/package.json
+++ b/examples/budget-allocator-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-budget-allocator",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Budget allocator MCP App Server with interactive visualization",
   "repository": {
@@ -26,7 +26,7 @@
     "serve": "bun --watch main.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chart.js": "^4.4.0",
     "cors": "^2.8.5",

--- a/examples/cohort-heatmap-server/package.json
+++ b/examples/cohort-heatmap-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-cohort-heatmap",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Cohort heatmap MCP App Server for retention analysis",
   "repository": {
@@ -26,7 +26,7 @@
     "serve": "bun --watch main.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/customer-segmentation-server/package.json
+++ b/examples/customer-segmentation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-customer-segmentation",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Customer segmentation MCP App Server with filtering",
   "repository": {
@@ -26,7 +26,7 @@
     "serve": "bun --watch main.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chart.js": "^4.4.0",
     "cors": "^2.8.5",

--- a/examples/debug-server/package.json
+++ b/examples/debug-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-debug",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Debug MCP App Server for testing all SDK capabilities",
   "repository": {
@@ -34,7 +34,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.1.13"
   },

--- a/examples/integration-server/package.json
+++ b/examples/integration-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-server",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -15,7 +15,7 @@
     "serve": "bun --watch main.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/lazy-auth-server/package.json
+++ b/examples/lazy-auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-lazy-auth",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "MCP App example demonstrating lazy (on-demand) OAuth: public tools work unauthenticated, protected tools return 401 + WWW-Authenticate so the host runs the OAuth flow only when needed",
   "repository": {
@@ -22,7 +22,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/map-server/package.json
+++ b/examples/map-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-map",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "MCP App Server example with CesiumJS 3D globe and geocoding",
   "repository": {
@@ -26,7 +26,7 @@
     "serve": "bun --watch main.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/pdf-server/package.json
+++ b/examples/pdf-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-pdf",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "MCP server for loading and extracting text from PDF files with chunked pagination and interactive viewer",
   "repository": {
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@cantoo/pdf-lib": "^2.6.5",
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/qr-server/package.json
+++ b/examples/qr-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-qr",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "scripts": {
     "start": "uv run server.py",
@@ -8,7 +8,7 @@
     "build": "echo 'No build step needed for Python server'"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0"
   }
 }

--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/quickstart",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "private": true,
   "description": "Quickstart MCP App Server example",
@@ -15,7 +15,7 @@
     "start": "concurrently --raw \"cross-env NODE_ENV=development INPUT=mcp-app.html vite build --watch\" \"tsx watch main.ts\""
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0"

--- a/examples/say-server/package.json
+++ b/examples/say-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-say",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "description": "Streaming TTS MCP App Server with karaoke-style text highlighting",
   "repository": {
@@ -15,7 +15,7 @@
     "build": "echo 'No build step needed for Python server'"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0"
   }
 }

--- a/examples/scenario-modeler-server/package.json
+++ b/examples/scenario-modeler-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-scenario-modeler",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Financial scenario modeling MCP App Server",
   "repository": {
@@ -26,7 +26,7 @@
     "serve": "bun --watch main.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chart.js": "^4.4.0",
     "cors": "^2.8.5",

--- a/examples/shadertoy-server/package.json
+++ b/examples/shadertoy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-shadertoy",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "MCP App Server example for rendering ShaderToy-compatible GLSL shaders",
   "repository": {
@@ -24,7 +24,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/sheet-music-server/package.json
+++ b/examples/sheet-music-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-sheet-music",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "MCP App Server for rendering and playing sheet music from ABC notation",
   "repository": {
@@ -24,7 +24,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "abcjs": "^6.4.4",
     "cors": "^2.8.5",

--- a/examples/system-monitor-server/package.json
+++ b/examples/system-monitor-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-system-monitor",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "System monitor MCP App Server with real-time stats",
   "repository": {
@@ -26,7 +26,7 @@
     "serve": "bun --watch main.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chart.js": "^4.4.0",
     "cors": "^2.8.5",

--- a/examples/threejs-server/package.json
+++ b/examples/threejs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-threejs",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Three.js 3D visualization MCP App Server",
   "repository": {
@@ -26,7 +26,7 @@
     "serve": "bun --watch main.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/transcript-server/package.json
+++ b/examples/transcript-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-transcript",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "MCP App Server for live speech transcription",
   "repository": {
@@ -24,7 +24,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/video-resource-server/package.json
+++ b/examples/video-resource-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-video-resource",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "MCP App Server demonstrating video resources served as base64 blobs",
   "repository": {
@@ -24,7 +24,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/examples/wiki-explorer-server/package.json
+++ b/examples/wiki-explorer-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-wiki-explorer",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "description": "Wikipedia link explorer MCP App Server with graph visualization",
   "repository": {
@@ -26,7 +26,7 @@
     "serve": "bun --watch main.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cheerio": "^1.0.0",
     "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/ext-apps",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/ext-apps",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "workspaces": [
         "examples/*"
@@ -66,9 +66,9 @@
     },
     "examples/basic-host": {
       "name": "@modelcontextprotocol/ext-apps-basic-host",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -109,10 +109,10 @@
     },
     "examples/basic-server-preact": {
       "name": "@modelcontextprotocol/server-basic-preact",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -153,10 +153,10 @@
     },
     "examples/basic-server-react": {
       "name": "@modelcontextprotocol/server-basic-react",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -200,10 +200,10 @@
     },
     "examples/basic-server-solid": {
       "name": "@modelcontextprotocol/server-basic-solid",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -244,10 +244,10 @@
     },
     "examples/basic-server-svelte": {
       "name": "@modelcontextprotocol/server-basic-svelte",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -288,10 +288,10 @@
     },
     "examples/basic-server-vanillajs": {
       "name": "@modelcontextprotocol/server-basic-vanillajs",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -330,10 +330,10 @@
     },
     "examples/basic-server-vue": {
       "name": "@modelcontextprotocol/server-basic-vue",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -374,10 +374,10 @@
     },
     "examples/budget-allocator-server": {
       "name": "@modelcontextprotocol/server-budget-allocator",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
@@ -417,10 +417,10 @@
     },
     "examples/cohort-heatmap-server": {
       "name": "@modelcontextprotocol/server-cohort-heatmap",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -464,10 +464,10 @@
     },
     "examples/customer-segmentation-server": {
       "name": "@modelcontextprotocol/server-customer-segmentation",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
@@ -507,10 +507,10 @@
     },
     "examples/debug-server": {
       "name": "@modelcontextprotocol/server-debug",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.1.13"
       },
@@ -548,9 +548,9 @@
       "license": "MIT"
     },
     "examples/integration-server": {
-      "version": "1.7.2",
+      "version": "1.7.3",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -593,10 +593,10 @@
     },
     "examples/lazy-auth-server": {
       "name": "@modelcontextprotocol/server-lazy-auth",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -635,10 +635,10 @@
     },
     "examples/map-server": {
       "name": "@modelcontextprotocol/server-map",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -677,11 +677,11 @@
     },
     "examples/pdf-server": {
       "name": "@modelcontextprotocol/server-pdf",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
         "@cantoo/pdf-lib": "^2.6.5",
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -721,18 +721,18 @@
     },
     "examples/qr-server": {
       "name": "@modelcontextprotocol/server-qr",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0"
       }
     },
     "examples/quickstart": {
       "name": "@modelcontextprotocol/quickstart",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0"
@@ -761,19 +761,19 @@
     },
     "examples/say-server": {
       "name": "@modelcontextprotocol/server-say",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0"
       }
     },
     "examples/scenario-modeler-server": {
       "name": "@modelcontextprotocol/server-scenario-modeler",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
@@ -818,10 +818,10 @@
     },
     "examples/shadertoy-server": {
       "name": "@modelcontextprotocol/server-shadertoy",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -860,10 +860,10 @@
     },
     "examples/sheet-music-server": {
       "name": "@modelcontextprotocol/server-sheet-music",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "abcjs": "^6.4.4",
         "cors": "^2.8.5",
@@ -903,10 +903,10 @@
     },
     "examples/system-monitor-server": {
       "name": "@modelcontextprotocol/server-system-monitor",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
@@ -973,10 +973,10 @@
     },
     "examples/threejs-server": {
       "name": "@modelcontextprotocol/server-threejs",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -1022,10 +1022,10 @@
     },
     "examples/transcript-server": {
       "name": "@modelcontextprotocol/server-transcript",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -1065,10 +1065,10 @@
     },
     "examples/video-resource-server": {
       "name": "@modelcontextprotocol/server-video-resource",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -1107,10 +1107,10 @@
     },
     "examples/wiki-explorer-server": {
       "name": "@modelcontextprotocol/server-wiki-explorer",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cheerio": "^1.0.0",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/modelcontextprotocol/ext-apps"
   },
   "homepage": "https://github.com/modelcontextprotocol/ext-apps",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "MIT",
   "description": "MCP Apps SDK — Enable MCP servers to display interactive user interfaces in conversational clients.",
   "type": "module",


### PR DESCRIPTION
## Changes since 1.7.2

No SDK API changes in this release.

### Examples

- Add lazy-auth-server example demonstrating lazy (on-demand) OAuth (#679)
- Add lazy-auth-server to the npm publish and pkg-pr-new workflows so it gets published with this release

### Other

- Example dependency ranges on `@modelcontextprotocol/ext-apps` synced from `^1.0.0` to `^1.7.0` (output of `npm run bump`)

### Release process

After merging, create a GitHub Release with tag `v1.7.3` to trigger the npm publish workflow.