### PR TITLE
feat: add support for 'tools' permission

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -193,6 +193,12 @@ interface UIResourceMeta {
      * Maps to Permission Policy `clipboard-write` feature
      */
     clipboardWrite?: {},
+    /**
+     * Request WebMCP tools access
+     *
+     * Maps to Permission Policy `tools` feature
+     */
+    tools?: {},
   },
   /**
    * Dedicated origin for view
@@ -251,6 +257,7 @@ The resource content is returned via `resources/read`:
           microphone?: {};       // Request microphone access
           geolocation?: {};      // Request geolocation access
           clipboardWrite?: {};   // Request clipboard write access
+          tools?: {};            // Request WebMCP tools access
         };
         domain?: string;
         prefersBorder?: boolean;
@@ -694,6 +701,7 @@ interface HostCapabilities {
       microphone?: {};
       geolocation?: {};
       clipboardWrite?: {};
+      tools?: {};
     };
     /** CSP domains approved by the host. */
     csp?: {
@@ -1480,6 +1488,7 @@ These messages are reserved for web-based hosts that implement the recommended d
       microphone?: {},
       geolocation?: {},
       clipboardWrite?: {},
+      tools?: {},
     }
   }
 }

--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -2817,6 +2817,10 @@ describe("buildAllowAttribute", () => {
         "clipboard-write",
       );
     });
+
+    it("when only tools is set", () => {
+      expect(buildAllowAttribute({ tools: {} })).toBe("tools");
+    });
   });
 
   describe("returns multiple directives joined with '; '", () => {
@@ -2833,8 +2837,9 @@ describe("buildAllowAttribute", () => {
           microphone: {},
           geolocation: {},
           clipboardWrite: {},
+          tools: {},
         }),
-      ).toBe("camera; microphone; geolocation; clipboard-write");
+      ).toBe("camera; microphone; geolocation; clipboard-write; tools");
     });
   });
 });

--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -194,6 +194,7 @@ export function buildAllowAttribute(
   if (permissions.microphone) allowList.push("microphone");
   if (permissions.geolocation) allowList.push("geolocation");
   if (permissions.clipboardWrite) allowList.push("clipboard-write");
+  if (permissions.tools) allowList.push("tools");
 
   return allowList.join("; ");
 }

--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -374,6 +374,12 @@
                   "type": "object",
                   "properties": {},
                   "additionalProperties": false
+                },
+                "tools": {
+                  "description": "Request WebMCP tools access.\n\nMaps to Permission Policy `tools` feature.",
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
                 }
               },
               "additionalProperties": false
@@ -2727,6 +2733,12 @@
                       "type": "object",
                       "properties": {},
                       "additionalProperties": false
+                    },
+                    "tools": {
+                      "description": "Request WebMCP tools access.\n\nMaps to Permission Policy `tools` feature.",
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
                     }
                   },
                   "additionalProperties": false
@@ -4224,6 +4236,12 @@
               "type": "object",
               "properties": {},
               "additionalProperties": false
+            },
+            "tools": {
+              "description": "Request WebMCP tools access.\n\nMaps to Permission Policy `tools` feature.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -4263,6 +4281,12 @@
         },
         "clipboardWrite": {
           "description": "Request clipboard write access.\n\nMaps to Permission Policy `clipboard-write` feature.",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        },
+        "tools": {
+          "description": "Request WebMCP tools access.\n\nMaps to Permission Policy `tools` feature.",
           "type": "object",
           "properties": {},
           "additionalProperties": false
@@ -4390,6 +4414,12 @@
                 },
                 "clipboardWrite": {
                   "description": "Request clipboard write access.\n\nMaps to Permission Policy `clipboard-write` feature.",
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                },
+                "tools": {
+                  "description": "Request WebMCP tools access.\n\nMaps to Permission Policy `tools` feature.",
                   "type": "object",
                   "properties": {},
                   "additionalProperties": false

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -336,6 +336,17 @@ export const McpUiResourcePermissionsSchema = z.object({
     .describe(
       "Request clipboard write access.\n\nMaps to Permission Policy `clipboard-write` feature.",
     ),
+  /**
+   * @description Request WebMCP tools access.
+   *
+   * Maps to Permission Policy `tools` feature.
+   */
+  tools: z
+    .object({})
+    .optional()
+    .describe(
+      "Request WebMCP tools access.\n\nMaps to Permission Policy `tools` feature.",
+    ),
 });
 
 /**

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -686,6 +686,12 @@ export interface McpUiResourcePermissions {
    * Maps to Permission Policy `clipboard-write` feature.
    */
   clipboardWrite?: {};
+  /**
+   * @description Request WebMCP tools access.
+   *
+   * Maps to Permission Policy `tools` feature.
+   */
+  tools?: {};
 }
 
 /**


### PR DESCRIPTION
## Motivation and Context

This change adds support for the 'tools' permission from the WebMCP specification, mapping it to the [Permission Policy 'tools' feature](https://webmachinelearning.github.io/webmcp/#permissions-policy).

## How Has This Been Tested?

I've tried it locally by adding this code in my files:

```js
// mcp-app.ts

(document as any).modelContext.registerTool(
  {
    name: 'webmcp-get-time',
    description: 'Returns the current application time.',
    execute: () => {
      const time = new Date().toISOString();
      return { content: [{ type: 'text', text: time }] };
    },
  },
  { exposedTo: ['http://localhost:8080'] },
);
```
```js
// server.ts

  const permissions = { tools: {} };
  
  registerAppResource(
    server,
    resourceUri,
    resourceUri,
    {
      _meta: { ui: { permissions } },
      mimeType: RESOURCE_MIME_TYPE,
    },
    async () => {
      const html = await fs.readFile(path.join(DIST_DIR, 'mcp-app.html'), 'utf-8');

      return {
        contents: [{ uri: resourceUri, mimeType: RESOURCE_MIME_TYPE, text: html }],
      };
    },
  );
```

Then, I used [WebMCP - Model Context Tool Inspector](https://chromewebstore.google.com/detail/webmcp-model-context-tool/gbpdfapgefenggkahomfgkhfehlcenpd) extension to verify it was properly registered. Without this PR, registration fails because of the missing `allow=tools` on both iframes.

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/46c743e5-7843-47ad-b809-79ad3cb15bbc" />


## Breaking Changes
Nope.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed (I've assumed schema.json will be part of the documentation)

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
