### PR TITLE
fix: add explicit .js extensions to relative imports so declarations resolve under NodeNext/Node16

### DIFF
--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -14,8 +14,8 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod/v4";
 
-import { App } from "./app";
-import { LATEST_PROTOCOL_VERSION } from "./types";
+import { App } from "./app.js";
+import { LATEST_PROTOCOL_VERSION } from "./types.js";
 import {
   AppBridge,
   buildAllowAttribute,
@@ -23,7 +23,7 @@ import {
   isToolVisibilityModelOnly,
   isToolVisibilityAppOnly,
   type McpUiHostCapabilities,
-} from "./app-bridge";
+} from "./app-bridge.js";
 
 /** Wait for pending microtasks to complete */
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));

--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -3,8 +3,8 @@ import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
 import { Server, type ServerCapabilities } from "@modelcontextprotocol/server";
 import { z } from "zod/v4";
 
-import { App } from "./app";
-import { LATEST_PROTOCOL_VERSION } from "./types";
+import { App } from "./app.js";
+import { LATEST_PROTOCOL_VERSION } from "./types.js";
 import {
   AppBridge,
   buildAllowAttribute,
@@ -13,7 +13,7 @@ import {
   isToolVisibilityAppOnly,
   McpUiOpenLinkResultSchema,
   type McpUiHostCapabilities,
-} from "./app-bridge";
+} from "./app-bridge.js";
 
 /** Wait for pending microtasks to complete */
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));

--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -47,7 +47,7 @@ import {
   ProtocolOptions,
   RequestOptions,
 } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import { ProtocolWithEvents } from "./events";
+import { ProtocolWithEvents } from "./events.js";
 
 import {
   type AppNotification,
@@ -92,11 +92,11 @@ import {
   McpUiRequestDisplayModeResult,
   McpUiResourcePermissions,
   McpUiToolMeta,
-} from "./types";
-export * from "./types";
-export { RESOURCE_URI_META_KEY, RESOURCE_MIME_TYPE } from "./app";
-import { RESOURCE_URI_META_KEY } from "./app";
-export { PostMessageTransport } from "./message-transport";
+} from "./types.js";
+export * from "./types.js";
+export { RESOURCE_URI_META_KEY, RESOURCE_MIME_TYPE } from "./app.js";
+import { RESOURCE_URI_META_KEY } from "./app.js";
+export { PostMessageTransport } from "./message-transport.js";
 
 /**
  * Extract UI resource URI from tool metadata.

--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -34,7 +34,7 @@ import {
   EmptyResultSchema,
   LoggingMessageNotificationSchema,
 } from "@modelcontextprotocol/core";
-import { EventDispatcher } from "./events";
+import { EventDispatcher } from "./events.js";
 import type { ZodLiteral, ZodObject, ZodType } from "zod/v4";
 
 type MethodSchema = ZodObject<{
@@ -87,11 +87,11 @@ import {
   McpUiRequestDisplayModeResultSchema,
   McpUiResourcePermissions,
   McpUiToolMeta,
-} from "./types";
-export * from "./types";
-export { RESOURCE_URI_META_KEY, RESOURCE_MIME_TYPE } from "./constants";
-import { RESOURCE_URI_META_KEY } from "./constants";
-export { PostMessageTransport } from "./message-transport";
+} from "./types.js";
+export * from "./types.js";
+export { RESOURCE_URI_META_KEY, RESOURCE_MIME_TYPE } from "./constants.js";
+import { RESOURCE_URI_META_KEY } from "./constants.js";
+export { PostMessageTransport } from "./message-transport.js";
 
 /**
  * Extract UI resource URI from tool metadata.

--- a/src/app.ts
+++ b/src/app.ts
@@ -31,10 +31,10 @@ import {
   ToolAnnotations,
   ToolListChangedNotification,
 } from "@modelcontextprotocol/sdk/types.js";
-import { AppNotification, AppRequest, AppResult } from "./types";
-import { ProtocolWithEvents } from "./events";
+import { AppNotification, AppRequest, AppResult } from "./types.js";
+import { ProtocolWithEvents } from "./events.js";
 export { ProtocolWithEvents };
-import { PostMessageTransport } from "./message-transport";
+import { PostMessageTransport } from "./message-transport.js";
 import {
   LATEST_PROTOCOL_VERSION,
   McpUiAppCapabilities,
@@ -67,28 +67,28 @@ import {
   McpUiToolResultNotificationSchema,
   McpUiRequestDisplayModeRequest,
   McpUiRequestDisplayModeResultSchema,
-} from "./types";
+} from "./types.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   StandardSchemaV1,
   standardSchemaToJsonSchema,
   validateStandardSchema,
-} from "./standard-schema";
+} from "./standard-schema.js";
 import { z } from "zod/v4";
 
 export type {
   StandardSchemaV1,
   StandardSchemaWithJSON,
-} from "./standard-schema";
+} from "./standard-schema.js";
 
-export { PostMessageTransport } from "./message-transport";
-export * from "./types";
+export { PostMessageTransport } from "./message-transport.js";
+export * from "./types.js";
 export {
   applyHostStyleVariables,
   applyHostFonts,
   getDocumentTheme,
   applyDocumentTheme,
-} from "./styles";
+} from "./styles.js";
 
 /**
  * Metadata key for associating a UI resource URI with a tool.

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,10 +22,10 @@ import {
   type Transport,
 } from "@modelcontextprotocol/client";
 import { EmptyResultSchema } from "@modelcontextprotocol/core";
-export { RESOURCE_MIME_TYPE, RESOURCE_URI_META_KEY } from "./constants";
-import { EventDispatcher } from "./events";
-export { EventDispatcher } from "./events";
-import { PostMessageTransport } from "./message-transport";
+export { RESOURCE_MIME_TYPE, RESOURCE_URI_META_KEY } from "./constants.js";
+import { EventDispatcher } from "./events.js";
+export { EventDispatcher } from "./events.js";
+import { PostMessageTransport } from "./message-transport.js";
 import {
   LATEST_PROTOCOL_VERSION,
   McpUiAppCapabilities,
@@ -59,12 +59,12 @@ import {
   McpUiToolResultNotificationSchema,
   McpUiRequestDisplayModeRequest,
   McpUiRequestDisplayModeResultSchema,
-} from "./types";
+} from "./types.js";
 import {
   StandardSchemaV1,
   standardSchemaToJsonSchema,
   validateStandardSchema,
-} from "./standard-schema";
+} from "./standard-schema.js";
 import { z, type ZodLiteral, type ZodObject, type ZodType } from "zod/v4";
 
 type MethodSchema = ZodObject<{
@@ -92,16 +92,16 @@ function mergeAppCapabilities(
 export type {
   StandardSchemaV1,
   StandardSchemaWithJSON,
-} from "./standard-schema";
+} from "./standard-schema.js";
 
-export { PostMessageTransport } from "./message-transport";
-export * from "./types";
+export { PostMessageTransport } from "./message-transport.js";
+export * from "./types.js";
 export {
   applyHostStyleVariables,
   applyHostFonts,
   getDocumentTheme,
   applyDocumentTheme,
-} from "./styles";
+} from "./styles.js";
 
 /**
  * Metadata key for associating a UI resource URI with a tool.

--- a/src/message-transport.test.ts
+++ b/src/message-transport.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
-import { PostMessageTransport } from "./message-transport";
+import { PostMessageTransport } from "./message-transport.js";
 
 /**
  * Minimal `window` stub for bun's DOM-less test environment.

--- a/src/message-transport.test.ts
+++ b/src/message-transport.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import type { JSONRPCMessage } from "@modelcontextprotocol/client";
 
-import { PostMessageTransport } from "./message-transport";
+import { PostMessageTransport } from "./message-transport.js";
 
 /**
  * Minimal `window` stub for bun's DOM-less test environment.

--- a/src/message-transport.ts
+++ b/src/message-transport.ts
@@ -7,7 +7,7 @@ import {
   Transport,
   TransportSendOptions,
 } from "@modelcontextprotocol/sdk/shared/transport.js";
-import { TOOL_INPUT_PARTIAL_METHOD } from "./spec.types";
+import { TOOL_INPUT_PARTIAL_METHOD } from "./spec.types.js";
 
 /**
  * JSON-RPC transport using `window.postMessage` for iframe↔parent communication.

--- a/src/message-transport.ts
+++ b/src/message-transport.ts
@@ -5,7 +5,7 @@ import type {
   Transport,
   TransportSendOptions,
 } from "@modelcontextprotocol/client";
-import { TOOL_INPUT_PARTIAL_METHOD } from "./spec.types";
+import { TOOL_INPUT_PARTIAL_METHOD } from "./spec.types.js";
 
 /**
  * JSON-RPC transport using `window.postMessage` for iframe↔parent communication.

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -31,7 +31,7 @@
  * }
  * ```
  */
-export * from "./useApp";
-export * from "./useAutoResize";
-export * from "./useDocumentTheme";
-export * from "./useHostStyles";
+export * from "./useApp.js";
+export * from "./useAutoResize.js";
+export * from "./useDocumentTheme.js";
+export * from "./useHostStyles.js";

--- a/src/react/useApp.tsx
+++ b/src/react/useApp.tsx
@@ -6,8 +6,8 @@ import {
   AppOptions,
   McpUiAppCapabilities,
   PostMessageTransport,
-} from "../app";
-export * from "../app";
+} from "../app.js";
+export * from "../app.js";
 
 /**
  * Options for configuring the {@link useApp `useApp`} hook.

--- a/src/react/useApp.tsx
+++ b/src/react/useApp.tsx
@@ -5,8 +5,8 @@ import {
   AppOptions,
   McpUiAppCapabilities,
   PostMessageTransport,
-} from "../app";
-export * from "../app";
+} from "../app.js";
+export * from "../app.js";
 
 /**
  * Options for configuring the {@link useApp `useApp`} hook.

--- a/src/react/useAutoResize.ts
+++ b/src/react/useAutoResize.ts
@@ -1,5 +1,5 @@
 import { useEffect, RefObject } from "react";
-import { App } from "../app";
+import { App } from "../app.js";
 
 /**
  * React hook that automatically reports UI size changes to the host.

--- a/src/react/useDocumentTheme.ts
+++ b/src/react/useDocumentTheme.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { getDocumentTheme } from "../styles";
-import { McpUiTheme } from "../types";
+import { getDocumentTheme } from "../styles.js";
+import { McpUiTheme } from "../types.js";
 
 /**
  * React hook that provides the current document theme reactively.

--- a/src/react/useHostStyles.ts
+++ b/src/react/useHostStyles.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from "react";
-import { App } from "../app";
+import { App } from "../app.js";
 import {
   applyDocumentTheme,
   applyHostFonts,
   applyHostStyleVariables,
-} from "../styles";
-import { McpUiHostContext } from "../types";
+} from "../styles.js";
+import { McpUiHostContext } from "../types.js";
 
 /**
  * React hook that applies host style variables and theme as CSS custom properties.

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -6,7 +6,7 @@ import {
   RESOURCE_MIME_TYPE,
   getUiCapability,
   EXTENSION_ID,
-} from "./index";
+} from "./index.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 describe("registerAppTool", () => {

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -6,7 +6,7 @@ import {
   RESOURCE_MIME_TYPE,
   getUiCapability,
   EXTENSION_ID,
-} from "./index";
+} from "./index.js";
 import type { McpServer } from "@modelcontextprotocol/server";
 
 describe("registerAppTool", () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -52,7 +52,7 @@ import type {
   AnySchema,
   ZodRawShapeCompat,
 } from "@modelcontextprotocol/sdk/server/zod-compat.js";
-import type { StandardSchemaWithJSON } from "../standard-schema";
+import type { StandardSchemaWithJSON } from "../standard-schema.js";
 import type {
   ClientCapabilities,
   ReadResourceResult,

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,4 +1,4 @@
-import { McpUiStyles, McpUiTheme } from "./types";
+import { McpUiStyles, McpUiTheme } from "./types.js";
 
 /**
  * Get the current document theme from the root HTML element.


### PR DESCRIPTION
## Summary

Fixes #704.

The published type declarations use **extensionless relative import specifiers** (e.g. `import { ProtocolWithEvents } from "./events";` in `dist/src/app-bridge.d.ts`). `tsc` (`emitDeclarationOnly`) copies specifiers verbatim from `src`, and under `Node16`/`NodeNext` module resolution a relative specifier must carry an explicit extension — so these imports don't resolve for downstream consumers. Any type that transitively depends on one loses its members; most visibly, the recommended `bridge.addEventListener("sandboxready", …)` API (inherited from `ProtocolWithEvents` via `./events`) becomes invisible, producing `TS2339`.

This adds explicit `.js` extensions to every relative import/export specifier across `src`. It is **types-only** — runtime JavaScript is unaffected, since the `.js` bundles are produced by `Bun.build`, which inlines relative modules (no extensionless relative import survives at runtime). The change matches the existing external-SDK import style (e.g. `@modelcontextprotocol/sdk/shared/protocol.js`), which already uses explicit `.js`; only the relative imports were inconsistent. It is compatible with both the repo's `bundler`-mode type-check and `Bun.build` (both resolve `./x.js` → `./x.ts`). No bare package specifiers were touched.

## Verification

- **NodeNext repro from the issue** — a consumer `tsconfig` with `moduleResolution: NodeNext` and `index.ts` doing `bridge.addEventListener("sandboxready", () => {})`, type-checked against a freshly built `dist`:
  - Before: `index.ts: error TS2339: Property 'addEventListener' does not exist on type 'AppBridge'.` (`tsc --noEmit` exits 2)
  - After: `tsc --noEmit` exits **0**.
- `npm run prettier` — the changed files are clean.
- `npm test` — **373 pass, 2 skip, 0 fail** (types-only change; no test behavior affected).

Scope: 13 files, 35 relative specifiers under `src/**` (including the `*.test.ts` relative imports, for consistency).
