### PR TITLE
Synchronize `object-src 'none'` with `default-src 'none'`

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -289,6 +289,7 @@ When `_meta.ui` is present on **both**, the content-item value takes precedence.
   style-src 'self' 'unsafe-inline';
   img-src 'self' data:;
   media-src 'self' data:;
+  object-src 'none';
   connect-src 'none';
   ```
 


### PR DESCRIPTION
This change is purely editorial.

Section [§4. Content Security Policy Enforcement](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx#4-content-security-policy-enforcement) describes how hosts MUST construct CSP headers from resource metadata. It includes `object-src 'none'` and `default-src 'none'` which is technically redundant since `object-src` uses `default-src` as a fallback, per https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/object-src. Despite the redundancy, I think it's good to be verbose here.

Related, the [§Host Behavior](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx#host-behavior) describes a restrictive default CSP that Hosts MUST use if `ui.csp` is missing. This includes `default-src 'none'` which implicitly protects us from `<object>` and `<embed>` elements, but does not include `object-src 'none'` explicitly. This is technically fine, but we should synchronize these two sections, so this PR simply adds `object-src 'none'` to the restrictive default, for completeness, even though it has no observable effect on app content or even CSP violation reports (because `default-src 'none'` is already specified).