### PR TITLE
fix: preserve experimental capability settings

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -548,8 +548,8 @@ When the View sends an `ui/initialize` request to the Host, it MUST include its 
 
 ```typescript
 interface McpUiAppCapabilities {
-  /** Experimental features (structure TBD). */
-  experimental?: {};
+  /** Experimental features keyed by identifier. */
+  experimental?: Record<string, object>;
   /** App exposes MCP-style tools that the host can call. */
   tools?: {
     /** App supports tools/list_changed notifications. */
@@ -677,8 +677,8 @@ interface SupportedContentBlockModalities {
 }
 
 interface HostCapabilities {
-  /** Experimental features (structure TBD). */
-  experimental?: {};
+  /** Experimental features keyed by identifier. */
+  experimental?: Record<string, object>;
   /** Host supports opening external URLs. */
   openLinks?: {};
   /** Host supports file downloads via ui/download-file. */

--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -45,6 +45,9 @@ function createMockClient(
 const testHostInfo = { name: "TestHost", version: "1.0.0" };
 const testAppInfo = { name: "TestApp", version: "1.0.0" };
 const testHostCapabilities: McpUiHostCapabilities = {
+  experimental: {
+    "com.example/host-extension": { version: 1 },
+  },
   openLinks: {},
   serverTools: {},
   logging: {},
@@ -97,7 +100,12 @@ describe("App <-> AppBridge integration", () => {
     });
 
     it("Bridge receives app info and capabilities after initialization", async () => {
-      const appCapabilities = { tools: { listChanged: true } };
+      const appCapabilities = {
+        experimental: {
+          "com.example/app-extension": { version: 1 },
+        },
+        tools: { listChanged: true },
+      };
       app = new App(testAppInfo, appCapabilities, { autoResize: false });
 
       await bridge.connect(bridgeTransport);

--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -9,10 +9,19 @@
       "type": "object",
       "properties": {
         "experimental": {
-          "description": "Experimental features (structure TBD).",
+          "description": "Experimental features keyed by identifier.",
           "type": "object",
-          "properties": {},
-          "additionalProperties": false
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {},
+            "description": "Experimental features keyed by identifier."
+          }
         },
         "tools": {
           "description": "App exposes MCP-style tools that the host can call.",
@@ -298,10 +307,19 @@
       "type": "object",
       "properties": {
         "experimental": {
-          "description": "Experimental features (structure TBD).",
+          "description": "Experimental features keyed by identifier.",
           "type": "object",
-          "properties": {},
-          "additionalProperties": false
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {},
+            "description": "Experimental features keyed by identifier."
+          }
         },
         "openLinks": {
           "description": "Host supports opening external URLs.",
@@ -2537,10 +2555,19 @@
               "type": "object",
               "properties": {
                 "experimental": {
-                  "description": "Experimental features (structure TBD).",
+                  "description": "Experimental features keyed by identifier.",
                   "type": "object",
-                  "properties": {},
-                  "additionalProperties": false
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {},
+                    "description": "Experimental features keyed by identifier."
+                  }
                 },
                 "tools": {
                   "description": "App exposes MCP-style tools that the host can call.",
@@ -2651,10 +2678,19 @@
           "type": "object",
           "properties": {
             "experimental": {
-              "description": "Experimental features (structure TBD).",
+              "description": "Experimental features keyed by identifier.",
               "type": "object",
-              "properties": {},
-              "additionalProperties": false
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {},
+                "description": "Experimental features keyed by identifier."
+              }
             },
             "openLinks": {
               "description": "Host supports opening external URLs.",

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -496,11 +496,16 @@ export const McpUiRequestTeardownNotificationSchema = z.object({
  * @see {@link McpUiInitializeResult `McpUiInitializeResult`} for the initialization result that includes these capabilities
  */
 export const McpUiHostCapabilitiesSchema = z.object({
-  /** @description Experimental features (structure TBD). */
+  /** @description Experimental features keyed by identifier. */
   experimental: z
-    .object({})
+    .record(
+      z.string(),
+      z
+        .record(z.string(), z.any())
+        .describe("Experimental features keyed by identifier."),
+    )
     .optional()
-    .describe("Experimental features (structure TBD)."),
+    .describe("Experimental features keyed by identifier."),
   /** @description Host supports opening external URLs. */
   openLinks: z
     .object({})
@@ -583,11 +588,16 @@ export const McpUiHostCapabilitiesSchema = z.object({
  * @see {@link McpUiInitializeRequest `McpUiInitializeRequest`} for the initialization request that includes these capabilities
  */
 export const McpUiAppCapabilitiesSchema = z.object({
-  /** @description Experimental features (structure TBD). */
+  /** @description Experimental features keyed by identifier. */
   experimental: z
-    .object({})
+    .record(
+      z.string(),
+      z
+        .record(z.string(), z.any())
+        .describe("Experimental features keyed by identifier."),
+    )
     .optional()
-    .describe("Experimental features (structure TBD)."),
+    .describe("Experimental features keyed by identifier."),
   /** @description App exposes MCP-style tools that the host can call. */
   tools: z
     .object({

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -492,8 +492,8 @@ export interface McpUiRequestTeardownNotification {
  * @see {@link McpUiInitializeResult `McpUiInitializeResult`} for the initialization result that includes these capabilities
  */
 export interface McpUiHostCapabilities {
-  /** @description Experimental features (structure TBD). */
-  experimental?: {};
+  /** @description Experimental features keyed by identifier. */
+  experimental?: Record<string, object>;
   /** @description Host supports opening external URLs. */
   openLinks?: {};
   /** @description Host supports file downloads via ui/download-file. */
@@ -536,8 +536,8 @@ export interface McpUiHostCapabilities {
  * @see {@link McpUiInitializeRequest `McpUiInitializeRequest`} for the initialization request that includes these capabilities
  */
 export interface McpUiAppCapabilities {
-  /** @description Experimental features (structure TBD). */
-  experimental?: {};
+  /** @description Experimental features keyed by identifier. */
+  experimental?: Record<string, object>;
   /** @description App exposes MCP-style tools that the host can call. */
   tools?: {
     /** @description App supports tools/list_changed notifications. */


### PR DESCRIPTION
## Motivation

Experimental App and Host capability entries are parsed as empty objects, stripping namespaced declarations during `ui/initialize`. Preserve their keys and settings in both capability maps.
