### PR TITLE
fix: include portal content in auto-resize

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1890,7 +1890,7 @@ export class App extends ProtocolWithEvents<
         // Out-of-flow descendants (for example, menus rendered in a portal)
         // do not contribute to the html element's intrinsic height.
         const clippingBottoms = new WeakMap<Element, number>();
-        document.body.querySelectorAll("*").forEach((element) => {
+        const measureElement = (element: Element) => {
           const rect = element.getBoundingClientRect();
           const parentElement = element.parentElement;
           const inheritedClippingBottom =
@@ -1909,7 +1909,9 @@ export class App extends ProtocolWithEvents<
                 : Math.min(rect.bottom, inheritedClippingBottom),
             );
           }
-        });
+        };
+        measureElement(document.body);
+        document.body.querySelectorAll("*").forEach(measureElement);
 
         height = Math.ceil(height);
         html.style.height = originalHeight;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1828,10 +1828,11 @@ export class App extends ProtocolWithEvents<
   }
 
   /**
-   * Set up automatic size change notifications using ResizeObserver.
+   * Set up automatic size change notifications using ResizeObserver and MutationObserver.
    *
-   * Observes both `document.documentElement` and `document.body` for size changes
-   * and automatically sends `ui/notifications/size-changed` notifications to the host.
+   * Observes both `document.documentElement` and `document.body` for size changes,
+   * and the document for mutations that can affect out-of-flow content such as portals.
+   * Automatically sends `ui/notifications/size-changed` notifications to the host.
    * The notifications are debounced using requestAnimationFrame to avoid duplicates.
    *
    * Note: This method is automatically called by `connect()` if the `autoResize`
@@ -1858,6 +1859,7 @@ export class App extends ProtocolWithEvents<
    */
   setupSizeChangedNotifications() {
     let scheduled = false;
+    let animationFrameId: number | undefined;
     let lastWidth = 0;
     let lastHeight = 0;
 
@@ -1866,7 +1868,7 @@ export class App extends ProtocolWithEvents<
         return;
       }
       scheduled = true;
-      requestAnimationFrame(() => {
+      animationFrameId = requestAnimationFrame(() => {
         scheduled = false;
         const html = document.documentElement;
 
@@ -1882,8 +1884,36 @@ export class App extends ProtocolWithEvents<
         // destroying their scroll positions.
         const originalHeight = html.style.height;
         html.style.height = "max-content";
-        const height = Math.ceil(html.getBoundingClientRect().height);
+        const htmlRect = html.getBoundingClientRect();
+        let height = htmlRect.height;
+
+        // Out-of-flow descendants (for example, menus rendered in a portal)
+        // do not contribute to the html element's intrinsic height.
+        const clippingBottoms = new WeakMap<Element, number>();
+        document.body.querySelectorAll("*").forEach((element) => {
+          const rect = element.getBoundingClientRect();
+          const parentElement = element.parentElement;
+          const inheritedClippingBottom =
+            (parentElement && clippingBottoms.get(parentElement)) ?? Infinity;
+          height = Math.max(
+            height,
+            Math.min(rect.bottom, inheritedClippingBottom) - htmlRect.top,
+          );
+
+          if (element.childElementCount > 0) {
+            const overflowY = getComputedStyle(element).overflowY;
+            clippingBottoms.set(
+              element,
+              overflowY === "visible"
+                ? inheritedClippingBottom
+                : Math.min(rect.bottom, inheritedClippingBottom),
+            );
+          }
+        });
+
+        height = Math.ceil(height);
         html.style.height = originalHeight;
+        mutationObserver.takeRecords();
 
         const width = Math.ceil(window.innerWidth);
 
@@ -1903,7 +1933,21 @@ export class App extends ProtocolWithEvents<
     resizeObserver.observe(document.documentElement);
     resizeObserver.observe(document.body);
 
-    return () => resizeObserver.disconnect();
+    const mutationObserver = new MutationObserver(sendBodySizeChanged);
+    mutationObserver.observe(document.documentElement, {
+      attributes: true,
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+      if (animationFrameId !== undefined) {
+        cancelAnimationFrame(animationFrameId);
+      }
+    };
   }
 
   /**

--- a/src/app.ts
+++ b/src/app.ts
@@ -1911,7 +1911,15 @@ export class App extends ProtocolWithEvents<
           }
         };
         measureElement(document.body);
-        document.body.querySelectorAll("*").forEach(measureElement);
+        const treeWalker = document.createTreeWalker(
+          document.body,
+          NodeFilter.SHOW_ELEMENT,
+        );
+        let element = treeWalker.nextNode() as Element | null;
+        while (element) {
+          measureElement(element);
+          element = treeWalker.nextNode() as Element | null;
+        }
 
         height = Math.ceil(height);
         html.style.height = originalHeight;

--- a/tests/e2e/auto-resize.spec.ts
+++ b/tests/e2e/auto-resize.spec.ts
@@ -57,6 +57,10 @@ test("auto-resize tracks out-of-flow portal content", async ({ page }) => {
       '<div class="scroll"><div class="scroll-content"></div></div>';
     await waitForMeasurement();
 
+    document.body.style.cssText = "height: 120px; overflow: auto";
+    document.body.innerHTML = '<div class="scroll-content"></div>';
+    await waitForMeasurement();
+
     cleanup();
     document.body.append(portal);
     await waitForMeasurement();
@@ -64,5 +68,5 @@ test("auto-resize tracks out-of-flow portal content", async ({ page }) => {
     return reportedSizes;
   });
 
-  expect(sizes.map(({ height }) => height)).toEqual([100, 400, 600, 100]);
+  expect(sizes.map(({ height }) => height)).toEqual([100, 400, 600, 100, 120]);
 });

--- a/tests/e2e/auto-resize.spec.ts
+++ b/tests/e2e/auto-resize.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+import { resolve } from "node:path";
+
+test("auto-resize tracks out-of-flow portal content", async ({ page }) => {
+  await page.route("**/app-with-deps.js", (route) =>
+    route.fulfill({
+      contentType: "text/javascript",
+      path: resolve("dist/src/app-with-deps.js"),
+    }),
+  );
+  await page.goto("/");
+
+  const sizes = await page.evaluate(async () => {
+    document.open();
+    document.write(`<!doctype html>
+      <style>
+        html, body { margin: 0; }
+        #content { height: 100px; }
+        #portal { position: absolute; top: 300px; height: 100px; }
+        .scroll { height: 100px; overflow: auto; }
+        .scroll-content { height: 1000px; }
+      </style>
+      <div id="content"></div>`);
+    document.close();
+
+    const { App } = await import("/app-with-deps.js");
+    const app = new App(
+      { name: "auto-resize-test", version: "1.0.0" },
+      {},
+      { autoResize: false },
+    );
+    const reportedSizes: Array<{ width?: number; height?: number }> = [];
+    app.sendSizeChanged = async (size) => {
+      reportedSizes.push(size);
+    };
+
+    const waitForMeasurement = async () => {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    };
+
+    const cleanup = app.setupSizeChangedNotifications();
+    await waitForMeasurement();
+
+    const portal = document.createElement("div");
+    portal.id = "portal";
+    document.body.append(portal);
+    await waitForMeasurement();
+
+    portal.style.top = "500px";
+    await waitForMeasurement();
+
+    portal.remove();
+    await waitForMeasurement();
+
+    document.body.innerHTML =
+      '<div class="scroll"><div class="scroll-content"></div></div>';
+    await waitForMeasurement();
+
+    cleanup();
+    document.body.append(portal);
+    await waitForMeasurement();
+
+    return reportedSizes;
+  });
+
+  expect(sizes.map(({ height }) => height)).toEqual([100, 400, 600, 100]);
+});


### PR DESCRIPTION
## Summary

Fixes #686.

Automatic app resizing previously measured only the intrinsic `html` height. Out-of-flow UI rendered through portals, such as menus, dialogs, and popovers, does not contribute to that height, so hosts could keep the iframe too short and clip the portal content.

This change:

- includes the visible bottom edge of out-of-flow descendants in the reported height
- observes document mutations so portal insertion, movement, and removal trigger a measurement
- respects ancestor overflow clipping, so content inside a fixed-height scroll container does not incorrectly expand the iframe
- keeps the existing `requestAnimationFrame` debounce and size deduplication
- disconnects both observers and cancels pending animation work during cleanup

## Before

A real Chromium reproduction with 100px of in-flow content and an absolutely positioned portal from 300px to 400px emitted only:

```json
[{"width":1280,"height":100}]
```

The host therefore had no signal that the portal extended to 400px.

## After

The Playwright regression exercises initial layout, portal insertion, portal movement, portal removal, clipped scroll content, deduplication, and cleanup. Its height sequence is:

```text
[100, 400, 600, 100]
```

Replacing the content with a 100px `overflow: auto` container whose child is 1000px tall emits no spurious 1000px resize. Re-inserting the portal after cleanup emits no notification.

## Validation

- `npm run build`
- `npm test`: 374 passed, 1 skipped, 0 failed
- `EXAMPLE=say-server npx playwright test tests/e2e/auto-resize.spec.ts --project=chromium --reporter=line`: 1 passed
- `npx prettier --check src/app.ts tests/e2e/auto-resize.spec.ts`
- repository pre-commit hooks, including all example builds

## Tradeoffs and risk

Measuring portal extent requires inspecting rendered descendant bounds. The work is coalesced to at most one measurement per animation frame, and computed styles are read only for elements with descendants where a clipping boundary could affect their children. Existing width behavior and protocol messages are unchanged.

The mutation observer watches structure, text, and attributes because portal geometry can change without resizing `html` or `body`. Observer records caused by the temporary intrinsic-height style are drained after measurement to avoid feedback loops.

No untrusted data is evaluated or transmitted; the change only reads local layout geometry and reports the same width/height notification shape as before.