### PR TITLE
docs(csp-cors): note that a rejected ui.domain stops the app rendering

### DIFF
--- a/docs/csp-cors.md
+++ b/docs/csp-cors.md
@@ -60,5 +60,10 @@ registerAppResource(
 
 Note that `_meta.ui.csp` and `_meta.ui.domain` are set in the `contents[]` objects returned by the resource read callback, not in `registerAppResource()`'s config object.
 
+> [!IMPORTANT]
+> Hosts validate `_meta.ui.domain` when it is present, and a value they do not accept can stop the app rendering entirely rather than falling back to the default origin. On Claude, a domain that doesn't match the expected value means no iframe is created at all, reported only as a generic failure to reach the server. Omitting the field is safe — the host uses its default sandbox origin — so only set it when you need a stable origin to allowlist.
+>
+> When deriving the value, hash exactly the endpoint URL the app is connected as. A trailing slash, a missing path segment, or a different scheme each produce a different hash, and therefore a domain the host rejects.
+
 > [!NOTE]
 > For full examples that configures CSP, see: [`examples/sheet-music-server/`](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/sheet-music-server) (`connectDomains`) and [`examples/map-server/`](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/map-server) (`connectDomains` and `resourceDomains`).


### PR DESCRIPTION
## Summary

`docs/csp-cors.md` introduces `_meta.ui.domain` as the way to give an app a stable origin for an API server to allowlist, and #309 clarified that its format is host-dependent. Neither says what happens when the value isn't one the host accepts, and the answer isn't the intuitive one: the app doesn't fall back to the default sandbox origin, it doesn't render at all.

## Why this is worth documenting

Measured against claude.ai web — one probe server, one endpoint, `_meta.ui.domain` as the only variable between arms, 36 renders each in a fresh conversation:

| `_meta.ui.domain` | iframe mounted |
| --- | --- |
| computed `sha256(endpoint)[:32] + ".claudemcpcontent.com"` | 10/10 |
| absent | 10/10 |
| present, not the expected value | **0/8** |

Because the field is documented as a CORS convenience and marked optional, it reads as safe to set speculatively. It isn't: a server that adds it while hashing an endpoint URL spelled slightly differently from the one the client connected with — a trailing slash, a missing path segment, a different scheme — converts a working app into one that doesn't render, and the surfaced error is generic enough to send you looking somewhere else entirely.

This is being hit in the wild. modelcontextprotocol/ext-apps#671 has a widely-upvoted comment recommending that servers add this field to fix non-rendering apps; following it with a slightly wrong endpoint string produces exactly this failure. Full measurements and method are in [anthropics/claude-ai-mcp#165](https://github.com/anthropics/claude-ai-mcp/issues/165#issuecomment-5142200204).

## Change

One `[!IMPORTANT]` callout in `docs/csp-cors.md`, next to the existing note and matching the callout style already used in the docs. No code or behaviour change.

- `npx prettier --check docs/csp-cors.md` passes.
- Docs-only, so no tests added.

Happy to mirror the same note on `McpUiResourceMeta.domain` in `src/spec.types.ts` (and the spec `.mdx`) if you'd rather it live with the type — I kept this to the docs page to stay atomic, since #309 already covers the type-level wording.