### PR TITLE
docs: add contextual launch pattern

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -503,6 +503,74 @@ await app.sendMessage({
 > [!NOTE]
 > For a full example that implements this pattern, see: [`examples/transcript-server/`](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/transcript-server).
 
+## Passing contextual launch data
+
+Use tool arguments for app-specific launch data, such as the item to open, the
+initial view, or an opaque handle for server-side state. The Host delivers the
+arguments to the View in `ui/notifications/tool-input`, so the same App can
+render different entry points without a separate launch protocol.
+
+**Server-side**: Define the launch data in the tool's input schema. Prefer
+bounded values and opaque handles over embedding sensitive state.
+
+<!-- prettier-ignore -->
+```tsx source="./patterns.tsx#contextualLaunchServer"
+registerAppTool(
+  server,
+  "open-discussion",
+  {
+    title: "Open protocol discussion",
+    description: "Open a protocol discussion in an interactive view",
+    inputSchema: {
+      discussionNumber: z.number().int().positive(),
+      view: z.enum(["summary", "debate", "migration-feedback"]),
+      contextHandle: z.string().optional(),
+    },
+    _meta: {
+      ui: { resourceUri: "ui://protocol/discussion.html" },
+    },
+  },
+  async ({ discussionNumber, view, contextHandle }) => ({
+    content: [
+      { type: "text", text: `Opened discussion #${discussionNumber}` },
+    ],
+    structuredContent: { discussionNumber, view, contextHandle },
+  }),
+);
+```
+
+**Client-side**: Handle the complete tool input and render the requested entry
+point. Register the handler before connecting so the View does not miss the
+notification.
+
+<!-- prettier-ignore -->
+```ts source="./patterns.tsx#contextualLaunchClient"
+interface DiscussionLaunchInput {
+  discussionNumber: number;
+  view: "summary" | "debate" | "migration-feedback";
+  contextHandle?: string;
+}
+
+app.ontoolinput = ({ arguments: input }) => {
+  const launch = input as unknown as DiscussionLaunchInput;
+  renderDiscussion(launch);
+};
+```
+
+Tool arguments are application input, not proof of user identity or trusted
+launch provenance. Treat them as untrusted even when a Host or model supplied
+them. Use the MCP authorization flow for user identity, and resolve sensitive
+or durable state server-side from a short-lived, audience-bound opaque handle.
+Do not place credentials, raw conversation content, or personal data in launch
+arguments.
+
+If multiple tools point to the same UI resource, a Host can identify the
+invoking tool through `hostContext.toolInfo`. This field is currently optional,
+so an App that requires deterministic routing should also include an explicit
+discriminator such as `view` in its tool input. See
+[issue #492](https://github.com/modelcontextprotocol/ext-apps/issues/492) for
+the discussion about making invoking-tool information consistently available.
+
 ## Persisting view state
 
 For recoverable view state (e.g., current page in a PDF viewer, camera position in a map), use [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) with a stable identifier provided by the server.

--- a/docs/patterns.tsx
+++ b/docs/patterns.tsx
@@ -360,6 +360,61 @@ function hostContextReact() {
 }
 
 /**
+ * Example: Passing contextual launch data (server-side)
+ */
+function contextualLaunchServer(server: McpServer) {
+  //#region contextualLaunchServer
+  registerAppTool(
+    server,
+    "open-discussion",
+    {
+      title: "Open protocol discussion",
+      description: "Open a protocol discussion in an interactive view",
+      inputSchema: {
+        discussionNumber: z.number().int().positive(),
+        view: z.enum(["summary", "debate", "migration-feedback"]),
+        contextHandle: z.string().optional(),
+      },
+      _meta: {
+        ui: { resourceUri: "ui://protocol/discussion.html" },
+      },
+    },
+    async ({ discussionNumber, view, contextHandle }) => ({
+      content: [
+        { type: "text", text: `Opened discussion #${discussionNumber}` },
+      ],
+      structuredContent: { discussionNumber, view, contextHandle },
+    }),
+  );
+  //#endregion contextualLaunchServer
+}
+
+/**
+ * Example: Passing contextual launch data (client-side)
+ */
+function contextualLaunchClient(
+  app: App,
+  renderDiscussion: (input: {
+    discussionNumber: number;
+    view: "summary" | "debate" | "migration-feedback";
+    contextHandle?: string;
+  }) => void,
+) {
+  //#region contextualLaunchClient
+  interface DiscussionLaunchInput {
+    discussionNumber: number;
+    view: "summary" | "debate" | "migration-feedback";
+    contextHandle?: string;
+  }
+
+  app.ontoolinput = ({ arguments: input }) => {
+    const launch = input as unknown as DiscussionLaunchInput;
+    renderDiscussion(launch);
+  };
+  //#endregion contextualLaunchClient
+}
+
+/**
  * Example: Persisting view state (server-side)
  */
 function persistViewStateServer(url: string, title: string, pageCount: number) {
@@ -464,6 +519,8 @@ void binaryBlobResourceServer;
 void binaryBlobResourceClient;
 void hostContextVanillaJs;
 void hostContextReact;
+void contextualLaunchServer;
+void contextualLaunchClient;
 void persistViewStateServer;
 void persistViewState;
 void visibilityBasedPause;


### PR DESCRIPTION
## What changed

- document tool arguments as the portable way to pass app-specific launch data
- add type-checked server and View examples for multiple contextual entry points
- distinguish launch input from authenticated identity or trusted host provenance
- document the current `hostContext.toolInfo` limitation and link issue #492

## Why

Telegram and Farcaster make contextual launches useful through small entry parameters, but MCP Apps already has the necessary transport: tool arguments arrive through `ui/notifications/tool-input`. Documenting that mapping gives builders a portable pattern without adding a new protocol primitive.

The security guidance recommends bounded inputs and opaque server-side handles, and warns against putting credentials, raw conversation content, or personal data in launch arguments.

## Prototype validation

The pattern is now exercised by [Discussion Capsule](https://github.com/Chipagosfinest/mcp-discussion-capsule), a standalone read-only MCP App. Its `open_github_discussion` tool accepts a Discussion URL as an ordinary argument and returns source-grounded `structuredContent` for the linked view.

I tested it against ext-apps Discussion #606 through this repository's basic reference host:

- the real Discussion loaded with 4 comments, 4 participants, and 8 source-linked questions
- the app rendered through the sandbox with zero browser console errors
- host-message handoff, comment filters, source links, and draft selection worked
- the app never posts or mutates GitHub state

This prototype does not require a separate launch envelope or claim that tool input is authenticated provenance.

## Validation

- `npm run prettier`
- `npm test` — 374 passed, 1 skipped
- `npm exec typedoc -- --treatValidationWarningsAsErrors --emit none`
- pre-commit `npm run build:all` and `npm run prettier:fix`

Prototype repository:

- `npm test` — 7 passed
- `npm run build`
- live GitHub REST smoke test against Discussion #606
- Playwright interaction pass through the ext-apps basic host

## AI assistance disclosure

This PR and the linked prototype were researched and authored with Codex under Alec Gutman's direction. The contribution uses the existing MCP Apps tool-input lifecycle and adds documentation plus type-checked examples; it does not change the protocol or runtime.
