### PR TITLE
spec(draft): add split display mode

### DIFF
--- a/examples/basic-host/src/global.css
+++ b/examples/basic-host/src/global.css
@@ -38,3 +38,9 @@ html, body {
 code {
   font-size: 1em;
 }
+
+/* While a View is in split display mode, reserve the right-hand region for it
+   so the conversation column and the split View never overlap. */
+body:has([data-display-mode="split"]) {
+  margin-right: var(--split-view-width, 40vw);
+}

--- a/examples/basic-host/src/implementation.ts
+++ b/examples/basic-host/src/implementation.ts
@@ -1,4 +1,4 @@
-import { RESOURCE_MIME_TYPE, getToolUiResourceUri, type McpUiSandboxProxyReadyNotification, AppBridge, PostMessageTransport, type McpUiResourceCsp, type McpUiResourcePermissions, buildAllowAttribute, type McpUiUpdateModelContextRequest, type McpUiMessageRequest } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { RESOURCE_MIME_TYPE, getToolUiResourceUri, type McpUiSandboxProxyReadyNotification, AppBridge, PostMessageTransport, type McpUiDisplayMode, type McpUiResourceCsp, type McpUiResourcePermissions, buildAllowAttribute, type McpUiUpdateModelContextRequest, type McpUiMessageRequest } from "@modelcontextprotocol/ext-apps/app-bridge";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -262,15 +262,19 @@ function hookInitializedCallback(appBridge: AppBridge): Promise<void> {
 export type ModelContext = McpUiUpdateModelContextRequest["params"];
 export type AppMessage = McpUiMessageRequest["params"];
 
+/** Display modes this host supports and advertises to apps. */
+const HOST_AVAILABLE_DISPLAY_MODES = ["inline", "fullscreen", "split"] as const satisfies readonly McpUiDisplayMode[];
+export type HostDisplayMode = (typeof HOST_AVAILABLE_DISPLAY_MODES)[number];
+
 export interface AppBridgeCallbacks {
   onContextUpdate?: (context: ModelContext | null) => void;
   onMessage?: (message: AppMessage) => void;
-  onDisplayModeChange?: (mode: "inline" | "fullscreen") => void;
+  onDisplayModeChange?: (mode: HostDisplayMode) => void;
 }
 
 export interface AppBridgeOptions {
   containerDimensions?: { maxHeight?: number; width?: number } | { height: number; width?: number };
-  displayMode?: "inline" | "fullscreen";
+  displayMode?: HostDisplayMode;
 }
 
 export function newAppBridge(
@@ -296,7 +300,7 @@ export function newAppBridge(
       },
       containerDimensions: options?.containerDimensions ?? { maxHeight: 6000 },
       displayMode: options?.displayMode ?? "inline",
-      availableDisplayModes: ["inline", "fullscreen"],
+      availableDisplayModes: [...HOST_AVAILABLE_DISPLAY_MODES],
     },
   });
 
@@ -395,7 +399,7 @@ export function newAppBridge(
   // Handle display mode change requests from the app
   appBridge.onrequestdisplaymode = async (params) => {
     log.info("Display mode request from MCP App:", params);
-    const newMode = params.mode === "fullscreen" ? "fullscreen" : "inline";
+    const newMode = HOST_AVAILABLE_DISPLAY_MODES.find((m) => m === params.mode) ?? "inline";
     // Update host context and notify the app
     appBridge.sendHostContextChange({
       displayMode: newMode,

--- a/examples/basic-host/src/index.module.css
+++ b/examples/basic-host/src/index.module.css
@@ -183,6 +183,54 @@
       border-radius: 0;
     }
   }
+
+  /* Persistent, non-overlapping region docked to the right; the host's
+     conversation column shifts aside via the body:has() rule in global.css
+     and stays visible and interactive. */
+  &.split {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: var(--split-view-width, 40vw);
+    z-index: 900;
+    margin: 0;
+    padding: 1rem;
+    max-width: none;
+    background: var(--color-bg);
+    border: none;
+    border-left: 1px solid var(--color-border);
+    border-radius: 0;
+    display: flex;
+    flex-direction: column;
+
+    /* The split region is dedicated to the View */
+    .collapsiblePanel {
+      display: none;
+    }
+
+    iframe {
+      flex: 1;
+      height: 100%;
+      border: none;
+      border-radius: 0;
+    }
+  }
+}
+
+.splitResizeHandle {
+  position: absolute;
+  top: 0;
+  left: -3px;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  touch-action: none;
+  user-select: none;
+
+  &:hover {
+    background: var(--color-primary);
+  }
 }
 
 .appToolbar {

--- a/examples/basic-host/src/index.tsx
+++ b/examples/basic-host/src/index.tsx
@@ -2,7 +2,7 @@ import { getToolUiResourceUri, McpUiToolMetaSchema } from "@modelcontextprotocol
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { Component, type ErrorInfo, type ReactNode, StrictMode, Suspense, use, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { callTool, connectToServer, hasAppHtml, initializeApp, loadSandboxProxy, log, newAppBridge, type ServerInfo, type ToolCallInfo, type ModelContext, type AppMessage } from "./implementation";
+import { callTool, connectToServer, hasAppHtml, initializeApp, loadSandboxProxy, log, newAppBridge, type ServerInfo, type ToolCallInfo, type ModelContext, type AppMessage, type HostDisplayMode } from "./implementation";
 import { getTheme, toggleTheme, onThemeChange, type Theme } from "./theme";
 import styles from "./index.module.css";
 
@@ -417,6 +417,34 @@ function CollapsiblePanel({ icon, label, content, badge, defaultExpanded = false
 }
 
 
+// Keep the split region within sensible bounds: wide enough to be useful,
+// narrow enough that the conversation column stays usable.
+function setSplitViewWidth(clientX: number) {
+  const width = Math.min(
+    Math.max(window.innerWidth - clientX, 280),
+    Math.max(window.innerWidth - 320, 280),
+  );
+  document.documentElement.style.setProperty("--split-view-width", `${width}px`);
+}
+
+function SplitResizeHandle() {
+  return (
+    <div
+      className={styles.splitResizeHandle}
+      title="Drag to resize"
+      onPointerDown={(e) => {
+        e.preventDefault();
+        e.currentTarget.setPointerCapture(e.pointerId);
+      }}
+      onPointerMove={(e) => {
+        if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+          setSplitViewWidth(e.clientX);
+        }
+      }}
+    />
+  );
+}
+
 interface AppIFramePanelProps {
   toolCallInfo: Required<ToolCallInfo>;
   isDestroying?: boolean;
@@ -427,7 +455,7 @@ function AppIFramePanel({ toolCallInfo, isDestroying, onTeardownComplete }: AppI
   const appBridgeRef = useRef<ReturnType<typeof newAppBridge> | null>(null);
   const [modelContext, setModelContext] = useState<ModelContext | null>(null);
   const [messages, setMessages] = useState<AppMessage[]>([]);
-  const [displayMode, setDisplayMode] = useState<"inline" | "fullscreen">("inline");
+  const [displayMode, setDisplayMode] = useState<HostDisplayMode>("inline");
 
   useEffect(() => {
     const iframe = iframeRef.current!;
@@ -510,12 +538,16 @@ function AppIFramePanel({ toolCallInfo, isDestroying, onTeardownComplete }: AppI
   };
   const messagesText = messages.map(formatMessage).join("\n\n");
 
-  const panelClassName = displayMode === "fullscreen"
-    ? `${styles.appIframePanel} ${styles.fullscreen}`
-    : styles.appIframePanel;
+  // Presentation only: the iframe node stays mounted across mode changes,
+  // so View state survives inline <-> split transitions.
+  const panelClassName =
+    displayMode === "inline"
+      ? styles.appIframePanel
+      : `${styles.appIframePanel} ${styles[displayMode]}`;
 
   return (
-    <div className={panelClassName}>
+    <div className={panelClassName} data-display-mode={displayMode}>
+      {displayMode === "split" && <SplitResizeHandle />}
       <iframe ref={iframeRef} />
       {messages.length > 0 && (
         <CollapsiblePanel

--- a/examples/debug-server/mcp-app.html
+++ b/examples/debug-server/mcp-app.html
@@ -134,6 +134,7 @@
             <button id="display-inline-btn" class="btn-small">Inline</button>
             <button id="display-fullscreen-btn" class="btn-small">Fullscreen</button>
             <button id="display-pip-btn" class="btn-small">PiP</button>
+            <button id="display-split-btn" class="btn-small">Split</button>
           </div>
         </div>
 

--- a/examples/debug-server/src/mcp-app.ts
+++ b/examples/debug-server/src/mcp-app.ts
@@ -3,7 +3,11 @@
  *
  * This app exercises every capability, callback, and result format combination.
  */
-import { App, type McpUiHostContext } from "@modelcontextprotocol/ext-apps";
+import {
+  App,
+  type McpUiDisplayMode,
+  type McpUiHostContext,
+} from "@modelcontextprotocol/ext-apps";
 import "./global.css";
 import "./mcp-app.css";
 
@@ -99,6 +103,7 @@ const updateContextImageBtn = document.getElementById(
 const displayInlineBtn = document.getElementById("display-inline-btn")!;
 const displayFullscreenBtn = document.getElementById("display-fullscreen-btn")!;
 const displayPipBtn = document.getElementById("display-pip-btn")!;
+const displaySplitBtn = document.getElementById("display-split-btn")!;
 
 const linkUrlEl = document.getElementById("link-url") as HTMLInputElement;
 const openLinkBtn = document.getElementById("open-link-btn")!;
@@ -347,7 +352,10 @@ function handleHostContextChanged(ctx: McpUiHostContext): void {
 
 const app = new App(
   { name: "Debug App", version: "1.0.0" },
-  { tools: { listChanged: true } }, // Declare tools capability for oncalltool/onlisttools
+  {
+    tools: { listChanged: true }, // Declare tools capability for oncalltool/onlisttools
+    availableDisplayModes: ["inline", "fullscreen", "pip", "split"],
+  },
   { autoResize: false }, // We'll manage auto-resize ourselves for toggle demo
 );
 
@@ -513,9 +521,7 @@ updateContextImageBtn.addEventListener("click", async () => {
 // Display Mode Actions
 // ============================================================================
 
-async function requestDisplayMode(
-  mode: "inline" | "fullscreen" | "pip",
-): Promise<void> {
+async function requestDisplayMode(mode: McpUiDisplayMode): Promise<void> {
   try {
     const result = await app.requestDisplayMode({ mode });
     logEvent("display-mode-result", { mode, result });
@@ -529,6 +535,7 @@ displayFullscreenBtn.addEventListener("click", () =>
   requestDisplayMode("fullscreen"),
 );
 displayPipBtn.addEventListener("click", () => requestDisplayMode("pip"));
+displaySplitBtn.addEventListener("click", () => requestDisplayMode("split"));
 
 // ============================================================================
 // Link Action

--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -559,7 +559,7 @@ interface McpUiAppCapabilities {
    * Display modes the app supports. See Display Modes section for details.
    * @example ["inline", "fullscreen"]
    */
-  availableDisplayModes?: Array<"inline" | "fullscreen" | "pip">;
+  availableDisplayModes?: Array<"inline" | "fullscreen" | "pip" | "split">;
 }
 ```
 
@@ -589,7 +589,7 @@ interface HostContext {
     };
   };
   /** How the View is currently displayed */
-  displayMode?: "inline" | "fullscreen" | "pip";
+  displayMode?: "inline" | "fullscreen" | "pip" | "split";
   /** Display modes the host supports */
   availableDisplayModes?: string[];
   /** Container dimensions for the iframe. Specify either width or maxWidth, and either height or maxHeight. */
@@ -805,12 +805,21 @@ Views using the SDK automatically send size-changed notifications via ResizeObse
 Views can be displayed in different modes depending on the host's capabilities and the view's declared support.
 
 ```typescript
-type McpUiDisplayMode = "inline" | "fullscreen" | "pip";
+type McpUiDisplayMode = "inline" | "fullscreen" | "pip" | "split";
 ```
 
 - **inline**: Default mode, embedded within the host's content flow
 - **fullscreen**: View takes over the full screen/window
 - **pip**: Picture-in-picture, floating overlay
+- **split**: View is displayed in a persistent, non-overlapping region while the host's primary conversational interface remains visible and interactive
+
+#### Split Mode
+
+In `split` mode, the View occupies a dedicated region of the host UI (e.g., a side panel) that does not overlap the host's primary conversational interface. Both remain visible and interactive at the same time, allowing users to keep referencing the View as the conversation continues.
+
+- Host controls the orientation, placement, and dimensions of the split region, how (and whether) it can be resized, and how many split Views it permits at once.
+- Entering or leaving `split` mode SHOULD NOT inherently recreate the current View: it is a presentation change of the already-rendered View, and its state SHOULD be preserved across the transition.
+- This mode does not define reusing Views across separate tool calls; each tool call still renders a new View instance.
 
 #### Declaring Support
 
@@ -1177,7 +1186,7 @@ Host behavior:
   id: 3,
   method: "ui/request-display-mode",
   params: {
-    mode: "inline" | "fullscreen" | "pip"  // Requested display mode
+    mode: "inline" | "fullscreen" | "pip" | "split"  // Requested display mode
   }
 }
 
@@ -1186,7 +1195,7 @@ Host behavior:
   jsonrpc: "2.0",
   id: 3,
   result: {
-    mode: "inline" | "fullscreen" | "pip"  // Actual display mode set
+    mode: "inline" | "fullscreen" | "pip" | "split"  // Actual display mode set
   }
 }
 ```

--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -624,6 +624,77 @@ describe("App <-> AppBridge integration", () => {
     });
   });
 
+  describe("display mode negotiation", () => {
+    it("split crosses the handshake and round-trips through requestDisplayMode", async () => {
+      const [newAppTransport, newBridgeTransport] =
+        InMemoryTransport.createLinkedPair();
+      const splitApp = new App(
+        testAppInfo,
+        { availableDisplayModes: ["inline", "split"] },
+        { autoResize: false },
+      );
+      const splitBridge = new AppBridge(
+        createMockClient() as Client,
+        testHostInfo,
+        testHostCapabilities,
+        {
+          hostContext: {
+            availableDisplayModes: ["inline", "fullscreen", "split"],
+          },
+        },
+      );
+      splitBridge.onrequestdisplaymode = async ({ mode }) => ({ mode });
+
+      await splitBridge.connect(newBridgeTransport);
+      await splitApp.connect(newAppTransport);
+
+      expect(splitBridge.getAppCapabilities()?.availableDisplayModes).toEqual([
+        "inline",
+        "split",
+      ]);
+      expect(splitApp.getHostContext()?.availableDisplayModes).toEqual([
+        "inline",
+        "fullscreen",
+        "split",
+      ]);
+
+      const result = await splitApp.requestDisplayMode({ mode: "split" });
+      expect(result.mode).toBe("split");
+
+      await newAppTransport.close();
+      await newBridgeTransport.close();
+    });
+
+    it("default handler returns the current mode from host context", async () => {
+      const [newAppTransport, newBridgeTransport] =
+        InMemoryTransport.createLinkedPair();
+      const bridgeWithContext = new AppBridge(
+        createMockClient() as Client,
+        testHostInfo,
+        testHostCapabilities,
+        { hostContext: { displayMode: "fullscreen" } },
+      );
+
+      await bridgeWithContext.connect(newBridgeTransport);
+      await app.connect(newAppTransport);
+      const result = await app.requestDisplayMode({ mode: "split" });
+
+      expect(result.mode).toBe("fullscreen");
+
+      await newAppTransport.close();
+      await newBridgeTransport.close();
+    });
+
+    it("default handler falls back to inline when host context has no display mode", async () => {
+      await bridge.connect(bridgeTransport);
+      await app.connect(appTransport);
+
+      const result = await app.requestDisplayMode({ mode: "split" });
+
+      expect(result.mode).toBe("inline");
+    });
+  });
+
   describe("deprecated method aliases", () => {
     beforeEach(async () => {
       await bridge.connect(bridgeTransport);

--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -50,6 +50,10 @@
               {
                 "type": "string",
                 "const": "pip"
+              },
+              {
+                "type": "string",
+                "const": "split"
               }
             ],
             "description": "Display mode for UI presentation."
@@ -86,6 +90,10 @@
         {
           "type": "string",
           "const": "pip"
+        },
+        {
+          "type": "string",
+          "const": "split"
         }
       ],
       "description": "Display mode for UI presentation."
@@ -1141,6 +1149,10 @@
                 {
                   "type": "string",
                   "const": "pip"
+                },
+                {
+                  "type": "string",
+                  "const": "split"
                 }
               ]
             },
@@ -1160,6 +1172,10 @@
                   {
                     "type": "string",
                     "const": "pip"
+                  },
+                  {
+                    "type": "string",
+                    "const": "split"
                   }
                 ],
                 "description": "Display mode for UI presentation."
@@ -1904,6 +1920,10 @@
             {
               "type": "string",
               "const": "pip"
+            },
+            {
+              "type": "string",
+              "const": "split"
             }
           ]
         },
@@ -1923,6 +1943,10 @@
               {
                 "type": "string",
                 "const": "pip"
+              },
+              {
+                "type": "string",
+                "const": "split"
               }
             ],
             "description": "Display mode for UI presentation."
@@ -2596,6 +2620,10 @@
                       {
                         "type": "string",
                         "const": "pip"
+                      },
+                      {
+                        "type": "string",
+                        "const": "split"
                       }
                     ],
                     "description": "Display mode for UI presentation."
@@ -3505,6 +3533,10 @@
                 {
                   "type": "string",
                   "const": "pip"
+                },
+                {
+                  "type": "string",
+                  "const": "split"
                 }
               ]
             },
@@ -3524,6 +3556,10 @@
                   {
                     "type": "string",
                     "const": "pip"
+                  },
+                  {
+                    "type": "string",
+                    "const": "split"
                   }
                 ],
                 "description": "Display mode for UI presentation."
@@ -4105,6 +4141,10 @@
                 {
                   "type": "string",
                   "const": "pip"
+                },
+                {
+                  "type": "string",
+                  "const": "split"
                 }
               ],
               "description": "The display mode being requested."
@@ -4134,6 +4174,10 @@
             {
               "type": "string",
               "const": "pip"
+            },
+            {
+              "type": "string",
+              "const": "split"
             }
           ],
           "description": "The display mode that was actually set. May differ from requested if not supported."

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -23,7 +23,12 @@ export const McpUiThemeSchema = z
  * @description Display mode for UI presentation.
  */
 export const McpUiDisplayModeSchema = z
-  .union([z.literal("inline"), z.literal("fullscreen"), z.literal("pip")])
+  .union([
+    z.literal("inline"),
+    z.literal("fullscreen"),
+    z.literal("pip"),
+    z.literal("split"),
+  ])
   .describe("Display mode for UI presentation.");
 
 /**

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -36,7 +36,7 @@ export type McpUiTheme = "light" | "dark";
 /**
  * @description Display mode for UI presentation.
  */
-export type McpUiDisplayMode = "inline" | "fullscreen" | "pip";
+export type McpUiDisplayMode = "inline" | "fullscreen" | "pip" | "split";
 
 /**
  * @description CSS variable keys available to MCP apps for theming.

--- a/tests/e2e/display-mode-split.spec.ts
+++ b/tests/e2e/display-mode-split.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Split display mode (prototype): the View docks in a persistent,
+ * non-overlapping region while the host stays interactive, and View
+ * state survives inline ↔ split transitions.
+ */
+
+test.setTimeout(120000);
+
+function getAppFrame(page: Page) {
+  return page.frameLocator("iframe").first().frameLocator("iframe").first();
+}
+
+test("inline → split → inline preserves View state and keeps host interactive", async ({
+  page,
+}) => {
+  await page.goto("/?server=Debug+MCP+App+Server&call=true&theme=hide");
+  const app = getAppFrame(page);
+  await expect(app.locator(".log-entry", { hasText: "connected" })).toBeVisible(
+    { timeout: 30000 },
+  );
+
+  const splitPanel = page.locator(
+    '[class*="appIframePanel"][data-display-mode="split"]',
+  );
+  const callToolButton = page.locator('button:has-text("Call Tool")');
+
+  // Marker entry: gone if the transition ever recreates the iframe.
+  await app.locator("#log-info-btn").click();
+  const marker = app.locator(".log-entry", { hasText: "send-log" });
+  await expect(marker).toBeVisible();
+
+  await app.locator("#display-split-btn").click();
+  await expect(splitPanel).toBeVisible();
+  await expect(app.locator("#host-context-info")).toContainText("split");
+
+  // Host controls stay actionable and do not overlap the split region.
+  await callToolButton.click({ trial: true });
+  const [hostBox, splitBox] = await Promise.all([
+    page.locator('[class*="callToolPanel"]').boundingBox(),
+    splitPanel.boundingBox(),
+  ]);
+  expect(hostBox!.x + hostBox!.width).toBeLessThanOrEqual(splitBox!.x + 1);
+  await expect(marker).toBeVisible();
+
+  await app.locator("#display-inline-btn").click();
+  await expect(splitPanel).not.toBeVisible();
+  await expect(app.locator("#host-context-info")).toContainText("inline");
+  await expect(marker).toBeVisible();
+});


### PR DESCRIPTION
## Motivation and Context

Rich Interactive Views (spreadsheets, maps, dashboards, CAD viewers) scroll out of sight as a conversation continues, so users lose the UI they're actively working with. #684 asks for a pinned/split-screen presentation; #412 wants the same outcome via `pip`/side panels. The existing `inline`-alternative modes don't satisfy these use-cases: `fullscreen` hides the conversation, and `pip`s  floating overlay is too small for complex, information-dense visualizations or interfaces.

This is a **runnable design prototype** - happy to redirect it into an Extensions Track SEP if maintainers prefer.

Relates to #684, #412, and #430.

## Proposed semantics

> **split**: The View is displayed in a persistent, non-overlapping region while the host's primary conversational interface remains visible and interactive.

- The host controls orientation, placement, dimensions, resizing, and how many split Views it permits.
- Negotiation is unchanged: hosts that don't support `split` omit it from `availableDisplayModes`, and apps accept whatever mode the host returns.
- Entering or leaving `split` SHOULD NOT recreate the View — it's a presentation change, and View state SHOULD survive the transition.
- Out of scope: reusing Views across separate tool calls (that remains #430); each tool call still renders a new View instance.

## Prototype Screenshot

<img width="973" height="616" alt="Screenshot 2026-08-04 095702" src="https://github.com/user-attachments/assets/930ecdbc-0f61-402d-8991-b5df23bbc0ea" />

## Open question: how should a new display mode be introduced?

Adding a mode looks additive, but it raises two distinct compatibility questions with different roots:

- **App declaring `split` → older host.** The 2026-01-26 spec defines the app's declared mode list as a fixed set of known values, so a host that checks strictly may reject the initialization request outright — hosts built on this SDK do. Independent implementations may be more lenient; failure isn't universal, but the spec permits it.
- **Host advertising `split` → older app.** Here the spec is already forward-compatible (the host's advertised list is `string[]`), but the SDK restricts it to the known modes. Apps built with existing SDK releases therefore reject a spec-valid initialization response from any host advertising an unknown mode — even apps that never use display modes. (Reproduced with an in-memory host/app pair: `connect()` rejects during initialization.)

This PR also widens what the SDK accepts while `LATEST_PROTOCOL_VERSION` stays `2026-01-26`, so two SDK releases claiming the same protocol version would disagree about which messages are valid — and with the current SDK, a version bump alone wouldn't fix the first direction, since messages are validated before the version is selected.

For maintainers: should new modes arrive via `experimental` capabilities or a new protocol version? Should the app's declared list also become forward-compatible? And — separately from `split` — should the SDK's host-advertised list be loosened to the `string[]` the spec already defines? Happy to rework this PR to whichever shape is preferred.

## Changes

- `src/spec.types.ts`: add `"split"` to `McpUiDisplayMode`; `src/generated/*` regenerated via `npm run generate:schemas`
- `specification/draft/apps.mdx`: document the mode (dated stable spec untouched)
- `examples/debug-server`: add a "Split" display-mode button
- `examples/basic-host`: advertise `split` and dock the View in a resizable right-hand region; only the panel's className changes, so the iframe never remounts and View state survives inline ↔ split. Demonstrates one active split View; multi-view arbitration is not implemented
- Tests: unit coverage for negotiation, plus an E2E spec driving debug-server inline → split → inline and asserting both surfaces stay visible, interactive, and non-overlapping, and that View state survives

## Testing

- `npm run build`, `npm test` (375 pass), `npm run prettier`, typedoc validation — all green
- `EXAMPLE=debug-server npx playwright test tests/e2e/display-mode-split.spec.ts` ✅
- `EXAMPLE=debug-server npx playwright test tests/e2e/servers.spec.ts` ✅ (existing goldens still match)

To try it: `npm start`, pick **Debug MCP App Server**, Call Tool, then click **Split**. Drag the region's left edge to resize.

## AI disclosure

Written primarily by Claude Code (Claude Fable 5) from my design direction and cross-checked with Codex (gpt-5.6-sol).
I reviewed the full diff and test results per the [AI contribution policy](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/AI_POLICY.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)




