### PR TITLE
feat: add app homepage resource metadata

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -215,6 +215,19 @@ interface UIResourceMeta {
    */
   domain?: string,
   /**
+   * Public homepage URL for the app represented by this UI resource.
+   *
+   * This is distinct from `domain`, which configures the host-assigned sandbox
+   * origin. Hosts MAY expose this URL to help users learn more about or return
+   * to the app, but MUST treat it as an untrusted external link and apply their
+   * normal link validation, policy, and consent behavior. Its presence does not
+   * grant navigation permission or establish trust in the destination.
+   *
+   * @example
+   * "https://weather.example.com"
+   */
+  homepage?: string,
+  /**
    * Visual boundary preference
    *
    * Boolean controlling whether a visible border and background is provided by the host. Specifying an
@@ -253,6 +266,7 @@ The resource content is returned via `resources/read`:
           clipboardWrite?: {};   // Request clipboard write access
         };
         domain?: string;
+        homepage?: string;
         prefersBorder?: boolean;
       };
     };
@@ -262,7 +276,7 @@ The resource content is returned via `resources/read`:
 
 #### Metadata Location
 
-`UIResourceMeta` (CSP, permissions, domain, prefersBorder) may be provided on either or both:
+`UIResourceMeta` (CSP, permissions, domain, homepage, prefersBorder) may be provided on either or both:
 
 - **`resources/list`:** On the resource entry's `_meta.ui` field. Useful as a static default that hosts can review at connection time.
 - **`resources/read`:** On each content item's `_meta.ui` field. Useful for per-response overrides or dynamic metadata that is only known at read time.
@@ -311,6 +325,7 @@ Example:
         "connectDomains": ["https://api.openweathermap.org"],
         "resourceDomains": ["https://cdn.jsdelivr.net"]
       },
+      "homepage": "https://weather.example.com",
       "prefersBorder": true
     }
   }
@@ -328,6 +343,7 @@ Example:
           "connectDomains": ["https://api.openweathermap.org"],
           "resourceDomains": ["https://cdn.jsdelivr.net"]
         },
+        "homepage": "https://weather.example.com",
         "prefersBorder": true
       }
     }

--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -4268,6 +4268,10 @@
           "description": "Dedicated origin for view sandbox.\n\nUseful when views need stable, dedicated origins for OAuth callbacks, CORS policies, or API key allowlists.\n\n**Host-dependent:** The format and validation rules for this field are determined by each host. Servers MUST consult host-specific documentation for the expected domain format. Common patterns include:\n- Hash-based subdomains (e.g., `{hash}.claudemcpcontent.com`)\n- URL-derived subdomains (e.g., `www-example-com.oaiusercontent.com`)\n\nIf omitted, host uses default sandbox origin (typically per-conversation).",
           "type": "string"
         },
+        "homepage": {
+          "description": "Public homepage URL for the app represented by this UI resource.\n\nThis is distinct from `domain`, which configures the host-assigned sandbox\norigin. Hosts MAY expose this URL to\nhelp users learn more about or return to the app, but MUST treat it as an\nuntrusted external link and apply their normal link validation, policy,\nand consent behavior. Its presence does not grant navigation permission\nor establish trust in the destination.",
+          "type": "string"
+        },
         "prefersBorder": {
           "description": "Visual boundary preference - true if view prefers a visible border.\n\nBoolean requesting whether a visible border and background is provided by the host. Specifying an explicit value for this is recommended because hosts' defaults may vary.\n\n- `true`: request visible border + background\n- `false`: request no visible border + background\n- omitted: host decides border",
           "type": "boolean"

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -665,6 +665,27 @@ export const McpUiResourceMetaSchema = z.object({
       "Dedicated origin for view sandbox.\n\nUseful when views need stable, dedicated origins for OAuth callbacks, CORS policies, or API key allowlists.\n\n**Host-dependent:** The format and validation rules for this field are determined by each host. Servers MUST consult host-specific documentation for the expected domain format. Common patterns include:\n- Hash-based subdomains (e.g., `{hash}.claudemcpcontent.com`)\n- URL-derived subdomains (e.g., `www-example-com.oaiusercontent.com`)\n\nIf omitted, host uses default sandbox origin (typically per-conversation).",
     ),
   /**
+   * @description Public homepage URL for the app represented by this UI resource.
+   *
+   * This is distinct from `domain`, which configures the host-assigned sandbox
+   * origin. Hosts MAY expose this URL to
+   * help users learn more about or return to the app, but MUST treat it as an
+   * untrusted external link and apply their normal link validation, policy,
+   * and consent behavior. Its presence does not grant navigation permission
+   * or establish trust in the destination.
+   *
+   * @example
+   * ```ts
+   * "https://weather.example.com"
+   * ```
+   */
+  homepage: z
+    .string()
+    .optional()
+    .describe(
+      "Public homepage URL for the app represented by this UI resource.\n\nThis is distinct from `domain`, which configures the host-assigned sandbox\norigin. Hosts MAY expose this URL to\nhelp users learn more about or return to the app, but MUST treat it as an\nuntrusted external link and apply their normal link validation, policy,\nand consent behavior. Its presence does not grant navigation permission\nor establish trust in the destination.",
+    ),
+  /**
    * @description Visual boundary preference - true if view prefers a visible border.
    *
    * Boolean requesting whether a visible border and background is provided by the host. Specifying an explicit value for this is recommended because hosts' defaults may vary.

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -230,7 +230,9 @@ describe("registerAppResource", () => {
       "ui://test/view.html",
       {
         description: "A test resource",
-        _meta: { ui: {} },
+        _meta: {
+          ui: { homepage: "https://example.com/apps/my-resource" },
+        },
       },
       callback,
     );
@@ -240,6 +242,9 @@ describe("registerAppResource", () => {
     expect(capturedUri).toBe("ui://test/view.html");
     expect(capturedConfig?.mimeType).toBe(RESOURCE_MIME_TYPE);
     expect(capturedConfig?.description).toBe("A test resource");
+    expect(capturedConfig?._meta).toEqual({
+      ui: { homepage: "https://example.com/apps/my-resource" },
+    });
   });
 
   it("should allow custom MIME type to override default", () => {

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -719,6 +719,22 @@ export interface McpUiResourceMeta {
    */
   domain?: string;
   /**
+   * @description Public homepage URL for the app represented by this UI resource.
+   *
+   * This is distinct from `domain`, which configures the host-assigned sandbox
+   * origin. Hosts MAY expose this URL to
+   * help users learn more about or return to the app, but MUST treat it as an
+   * untrusted external link and apply their normal link validation, policy,
+   * and consent behavior. Its presence does not grant navigation permission
+   * or establish trust in the destination.
+   *
+   * @example
+   * ```ts
+   * "https://weather.example.com"
+   * ```
+   */
+  homepage?: string;
+  /**
    * @description Visual boundary preference - true if view prefers a visible border.
    *
    * Boolean requesting whether a visible border and background is provided by the host. Specifying an explicit value for this is recommended because hosts' defaults may vary.


### PR DESCRIPTION
## What changed

- adds optional `homepage` metadata to `McpUiResourceMeta`
- regenerates the Zod and JSON schemas
- documents the field in the draft MCP Apps specification and resource examples
- verifies `registerAppResource` preserves the metadata

## Why

`ui.domain` configures a host-assigned sandbox origin; it is not the app's public homepage. MCP servers and public app sites may also live at different locations, so hosts currently have no portable metadata they can use to help users learn more about or return to an app.

The documentation explicitly treats `homepage` as an untrusted external link. It does not grant navigation permission or establish destination trust; hosts retain their normal URL validation, policy, and consent behavior.

Closes #703.

## Validation

- `bun test src/server/index.test.ts src/generated/schema.test.ts`
- `npm run build`
- `npm run prettier`
- `npm exec typedoc -- --treatValidationWarningsAsErrors --emit none`
- repository pre-commit hook: `npm run build:all`
