### PR TITLE
fix: prefer tool title in app view chrome

### DIFF
--- a/examples/basic-host/src/index.tsx
+++ b/examples/basic-host/src/index.tsx
@@ -339,9 +339,14 @@ function ToolCallInfoPanel({ toolCallInfo, isDestroying, onRequestClose, onClose
       className={styles.toolCallInfoPanel}
       style={isDestroying ? { opacity: 0.5, pointerEvents: "none" } : undefined}
     >
-      {/* Row 1: Header with server:tool name and close button */}
+      {/* Row 1: Header with server:tool title and close button */}
       <div className={styles.appHeader}>
-        <span>{toolCallInfo.serverInfo.name}:<span className={styles.toolName}>{toolCallInfo.tool.name}</span></span>
+        <span>
+          {toolCallInfo.serverInfo.name}:
+          <span className={styles.toolName}>
+            {toolCallInfo.tool.title ?? toolCallInfo.tool.name}
+          </span>
+        </span>
         {onRequestClose && !isDestroying && (
           <button
             className={styles.closeButton}

--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -409,6 +409,7 @@ Example (app-only tool, hidden from model):
 - Resource MUST exist on the server
 - Host MUST use `resources/read` to fetch the referenced resource URI
 - Host MAY prefetch and cache UI resource content for performance optimization
+- When labeling host-provided chrome for a tool-instantiated View, Host SHOULD use the Tool's human-readable `title` when present, falling back to `name`
 - Since UI resources are primarily discovered through tool metadata, Servers MAY omit UI-only resources from `resources/list` and `notifications/resources/list_changed`
 
 #### Visibility:


### PR DESCRIPTION
## What changed

- updates the basic host to label tool-instantiated app chrome with `Tool.title`, falling back to `Tool.name`
- adds the same behavior as a draft specification recommendation

## Why

App views currently expose programmatic identifiers such as `get_report_app` even when a tool already provides a human-readable title. Reusing the standard `Tool.title` field fixes the user-facing mismatch without adding redundant app-specific metadata or coupling the display label to the callable tool name.

This also matches the broader Mini App pattern where host-provided chrome uses human-readable app/action metadata while machine identifiers remain internal.

Closes #740.

## Validation

- `npm run --workspace examples/basic-host build`
- `npm run prettier`
- repository pre-commit hook: `npm run build:all`
