### PR TITLE
feat: add UI preload and result-driven close controls

### DIFF
--- a/specification/draft/apps.mdx
+++ b/specification/draft/apps.mdx
@@ -340,9 +340,13 @@ Example:
 Tools are associated with UI resources through the `_meta.ui` field:
 
 ```typescript
+type McpUiToolPreload = "optional" | "disabled";
+
 interface McpUiToolMeta {
   /** URI of UI resource for rendering tool results */
   resourceUri?: string;
+  /** Whether the Host may preload the UI resource. Default: "optional" */
+  preload?: McpUiToolPreload;
   /**
    * Who can access this tool. Default: ["model", "app"]
    * - "model": Tool visible to and callable by the agent
@@ -402,6 +406,22 @@ Example (app-only tool, hidden from model):
 }
 ```
 
+Example (defer loading the View until the tool result is available):
+
+```json
+{
+  "name": "search_orders",
+  "description": "Search for matching orders",
+  "inputSchema": { "type": "object" },
+  "_meta": {
+    "ui": {
+      "resourceUri": "ui://orders/search-results",
+      "preload": "disabled"
+    }
+  }
+}
+```
+
 #### Behavior:
 
 - If `ui.resourceUri` is present and host supports MCP Apps, host renders tool results using the specified UI resource
@@ -410,6 +430,43 @@ Example (app-only tool, hidden from model):
 - Host MUST use `resources/read` to fetch the referenced resource URI
 - Host MAY prefetch and cache UI resource content for performance optimization
 - Since UI resources are primarily discovered through tool metadata, Servers MAY omit UI-only resources from `resources/list` and `notifications/resources/list_changed`
+
+#### Preloading:
+
+Hosts that recognize the `preload` field apply the following behavior:
+
+- `preload` defaults to `"optional"` if omitted
+- `"optional"`: Host MAY fetch the UI resource and initialize or display its View before tool execution completes
+- `"disabled"`: Host MUST wait for the tool result before fetching the UI resource for that invocation or initializing or displaying its View
+- `"disabled"` does not require a Host to evict a UI resource that is already cached from another invocation
+- After receiving a result without `_meta["ui/close"]: true`, Host MAY load and display the View normally
+- Hosts that do not recognize `preload` MAY ignore it and preserve their existing behavior
+
+#### Result-driven View closure:
+
+A Server MAY indicate that the View declared for a tool is not needed for a particular invocation by setting `_meta["ui/close"]` on its `CallToolResult`:
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "Found one matching order."
+    }
+  ],
+  "_meta": {
+    "ui/close": true
+  }
+}
+```
+
+Hosts that recognize the `ui/close` signal apply the following behavior:
+
+- The signal applies only to the invocation that produced the result
+- If its View has not been initialized or displayed, Host MUST suppress it
+- If its View has been initialized or displayed, Host MUST initiate graceful teardown using `ui/resource-teardown` and SHOULD wait for a response before unmounting it
+- The signal has no effect when it is omitted, set to `false`, or no View is associated with the invocation
+- Hosts that do not recognize `ui/close` MAY ignore it; Servers SHOULD provide meaningful non-UI content for those Hosts
 
 #### Visibility:
 

--- a/src/app-bridge.test.ts
+++ b/src/app-bridge.test.ts
@@ -19,9 +19,12 @@ import { LATEST_PROTOCOL_VERSION } from "./types";
 import {
   AppBridge,
   buildAllowAttribute,
+  getToolUiPreload,
   getToolUiResourceUri,
   isToolVisibilityModelOnly,
   isToolVisibilityAppOnly,
+  shouldCloseToolUi,
+  UI_CLOSE_META_KEY,
   type McpUiHostCapabilities,
 } from "./app-bridge";
 
@@ -2467,6 +2470,49 @@ describe("getToolUiResourceUri", () => {
         "Invalid UI resource URI",
       );
     });
+  });
+});
+
+describe("getToolUiPreload", () => {
+  it("defaults to optional when preload is omitted", () => {
+    expect(getToolUiPreload({})).toBe("optional");
+    expect(getToolUiPreload({ _meta: { ui: {} } })).toBe("optional");
+  });
+
+  it("returns an explicitly declared mode", () => {
+    expect(getToolUiPreload({ _meta: { ui: { preload: "optional" } } })).toBe(
+      "optional",
+    );
+    expect(getToolUiPreload({ _meta: { ui: { preload: "disabled" } } })).toBe(
+      "disabled",
+    );
+  });
+
+  it("ignores an unrecognized mode for forward compatibility", () => {
+    expect(getToolUiPreload({ _meta: { ui: { preload: "required" } } })).toBe(
+      "optional",
+    );
+  });
+});
+
+describe("shouldCloseToolUi", () => {
+  it("returns true for the ui/close signal", () => {
+    expect(shouldCloseToolUi({ _meta: { [UI_CLOSE_META_KEY]: true } })).toBe(
+      true,
+    );
+  });
+
+  it("returns false when the signal is absent or false", () => {
+    expect(shouldCloseToolUi({})).toBe(false);
+    expect(shouldCloseToolUi({ _meta: { [UI_CLOSE_META_KEY]: false } })).toBe(
+      false,
+    );
+  });
+
+  it("ignores non-boolean truthy values", () => {
+    expect(shouldCloseToolUi({ _meta: { [UI_CLOSE_META_KEY]: "true" } })).toBe(
+      false,
+    );
   });
 });
 

--- a/src/app-bridge.ts
+++ b/src/app-bridge.ts
@@ -91,11 +91,17 @@ import {
   McpUiRequestDisplayModeRequestSchema,
   McpUiRequestDisplayModeResult,
   McpUiResourcePermissions,
+  McpUiToolPreload,
   McpUiToolMeta,
+  McpUiToolResultMeta,
 } from "./types";
 export * from "./types";
-export { RESOURCE_URI_META_KEY, RESOURCE_MIME_TYPE } from "./app";
-import { RESOURCE_URI_META_KEY } from "./app";
+export {
+  RESOURCE_URI_META_KEY,
+  RESOURCE_MIME_TYPE,
+  UI_CLOSE_META_KEY,
+} from "./app";
+import { RESOURCE_URI_META_KEY, UI_CLOSE_META_KEY } from "./app";
 export { PostMessageTransport } from "./message-transport";
 
 /**
@@ -138,6 +144,33 @@ export function getToolUiResourceUri(tool: Partial<Tool>): string | undefined {
     throw new Error(`Invalid UI resource URI: ${JSON.stringify(uri)}`);
   }
   return undefined;
+}
+
+/**
+ * Get a tool's UI preload mode.
+ *
+ * @param tool - Tool object with optional UI metadata
+ * @returns The declared preload mode, or `"optional"` when omitted or unrecognized
+ */
+export function getToolUiPreload(tool: Partial<Tool>): McpUiToolPreload {
+  const uiMeta = tool._meta?.ui as McpUiToolMeta | undefined;
+  return uiMeta?.preload === "disabled" ? "disabled" : "optional";
+}
+
+/**
+ * Check whether a tool result requests closure of its associated View.
+ *
+ * The signal is scoped to the invocation that produced the result and is only
+ * active when `_meta["ui/close"]` is the literal boolean `true`.
+ *
+ * @param result - MCP tool execution result
+ * @returns True when the associated View should be suppressed or closed
+ */
+export function shouldCloseToolUi(
+  result: Pick<CallToolResult, "_meta">,
+): boolean {
+  const meta = result._meta as McpUiToolResultMeta | undefined;
+  return meta?.[UI_CLOSE_META_KEY] === true;
 }
 
 /**

--- a/src/app.ts
+++ b/src/app.ts
@@ -149,6 +149,17 @@ export {
 export const RESOURCE_URI_META_KEY = "ui/resourceUri";
 
 /**
+ * Metadata key for suppressing or closing the View associated with a tool
+ * invocation.
+ *
+ * A server sets this key to `true` in `CallToolResult._meta` when the result can
+ * be presented without the tool's declared UI resource. Hosts should suppress
+ * a pending View or gracefully tear down an initialized View for that specific
+ * invocation.
+ */
+export const UI_CLOSE_META_KEY = "ui/close";
+
+/**
  * MIME type for MCP UI resources.
  *
  * Identifies HTML content as an MCP App UI resource.

--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -5320,6 +5320,19 @@
         "resourceUri": {
           "type": "string"
         },
+        "preload": {
+          "description": "Whether the host may preload the UI resource. Default: \"optional\"\n- \"optional\": Host may preload or defer loading the UI resource\n- \"disabled\": Host waits for the tool result before loading the UI resource",
+          "anyOf": [
+            {
+              "type": "string",
+              "const": "optional"
+            },
+            {
+              "type": "string",
+              "const": "disabled"
+            }
+          ]
+        },
         "visibility": {
           "description": "Who can access this tool. Default: [\"model\", \"app\"]\n- \"model\": Tool visible to and callable by the agent\n- \"app\": Tool callable by the app from this server only",
           "type": "array",
@@ -5342,6 +5355,31 @@
         },
         "permissions": {
           "not": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "McpUiToolPreload": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "string",
+          "const": "optional"
+        },
+        {
+          "type": "string",
+          "const": "disabled"
+        }
+      ],
+      "description": "Controls whether the host may preload a tool's UI resource."
+    },
+    "McpUiToolResultMeta": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "ui/close": {
+          "description": "Whether the host should close or suppress the View associated\nwith this tool invocation. Default: false",
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/src/generated/schema.test.ts
+++ b/src/generated/schema.test.ts
@@ -123,8 +123,16 @@ export type McpUiToolVisibilitySchemaInferredType = z.infer<
   typeof generated.McpUiToolVisibilitySchema
 >;
 
+export type McpUiToolPreloadSchemaInferredType = z.infer<
+  typeof generated.McpUiToolPreloadSchema
+>;
+
 export type McpUiToolMetaSchemaInferredType = z.infer<
   typeof generated.McpUiToolMetaSchema
+>;
+
+export type McpUiToolResultMetaSchemaInferredType = z.infer<
+  typeof generated.McpUiToolResultMetaSchema
 >;
 
 export type McpUiClientCapabilitiesSchemaInferredType = z.infer<
@@ -303,8 +311,16 @@ expectType<spec.McpUiToolVisibility>(
 expectType<McpUiToolVisibilitySchemaInferredType>(
   {} as spec.McpUiToolVisibility,
 );
+expectType<spec.McpUiToolPreload>({} as McpUiToolPreloadSchemaInferredType);
+expectType<McpUiToolPreloadSchemaInferredType>({} as spec.McpUiToolPreload);
 expectType<spec.McpUiToolMeta>({} as McpUiToolMetaSchemaInferredType);
 expectType<McpUiToolMetaSchemaInferredType>({} as spec.McpUiToolMeta);
+expectType<spec.McpUiToolResultMeta>(
+  {} as McpUiToolResultMetaSchemaInferredType,
+);
+expectType<McpUiToolResultMetaSchemaInferredType>(
+  {} as spec.McpUiToolResultMeta,
+);
 expectType<spec.McpUiClientCapabilities>(
   {} as McpUiClientCapabilitiesSchemaInferredType,
 );

--- a/src/generated/schema.ts
+++ b/src/generated/schema.ts
@@ -716,6 +716,13 @@ export const McpUiToolVisibilitySchema = z
   .describe("Tool visibility scope - who can access the tool.");
 
 /**
+ * @description Controls whether the host may preload a tool's UI resource.
+ */
+export const McpUiToolPreloadSchema = z
+  .union([z.literal("optional"), z.literal("disabled")])
+  .describe("Controls whether the host may preload a tool's UI resource.");
+
+/**
  * @description UI-related metadata for tools.
  */
 export const McpUiToolMetaSchema = z.object({
@@ -728,6 +735,14 @@ export const McpUiToolMetaSchema = z.object({
    * ```
    */
   resourceUri: z.string().optional(),
+  /**
+   * @description Whether the host may preload the UI resource. Default: "optional"
+   * - "optional": Host may preload or defer loading the UI resource
+   * - "disabled": Host waits for the tool result before loading the UI resource
+   */
+  preload: McpUiToolPreloadSchema.optional().describe(
+    'Whether the host may preload the UI resource. Default: "optional"\n- "optional": Host may preload or defer loading the UI resource\n- "disabled": Host waits for the tool result before loading the UI resource',
+  ),
   /**
    * @description Who can access this tool. Default: ["model", "app"]
    * - "model": Tool visible to and callable by the agent
@@ -750,6 +765,22 @@ export const McpUiToolMetaSchema = z.object({
    * not the tool. Hosts ignore it here.
    */
   permissions: z.never().optional(),
+});
+
+/**
+ * @description MCP Apps metadata for a tool execution result.
+ */
+export const McpUiToolResultMetaSchema = z.object({
+  /**
+   * @description Whether the host should close or suppress the View associated
+   * with this tool invocation. Default: false
+   */
+  "ui/close": z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether the host should close or suppress the View associated\nwith this tool invocation. Default: false",
+    ),
 });
 
 /**

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -34,6 +34,7 @@
 import {
   RESOURCE_URI_META_KEY,
   RESOURCE_MIME_TYPE,
+  UI_CLOSE_META_KEY,
   McpUiResourceCsp,
   McpUiResourceMeta,
   McpUiToolMeta,
@@ -60,7 +61,7 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 
 // Re-exports for convenience
-export { RESOURCE_URI_META_KEY, RESOURCE_MIME_TYPE };
+export { RESOURCE_URI_META_KEY, RESOURCE_MIME_TYPE, UI_CLOSE_META_KEY };
 export type { ResourceMetadata, ToolCallback };
 
 /**

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -764,6 +764,11 @@ export interface McpUiRequestDisplayModeResult {
 export type McpUiToolVisibility = "model" | "app";
 
 /**
+ * @description Controls whether the host may preload a tool's UI resource.
+ */
+export type McpUiToolPreload = "optional" | "disabled";
+
+/**
  * @description UI-related metadata for tools.
  */
 export interface McpUiToolMeta {
@@ -776,6 +781,12 @@ export interface McpUiToolMeta {
    * ```
    */
   resourceUri?: string;
+  /**
+   * @description Whether the host may preload the UI resource. Default: "optional"
+   * - "optional": Host may preload or defer loading the UI resource
+   * - "disabled": Host waits for the tool result before loading the UI resource
+   */
+  preload?: McpUiToolPreload;
   /**
    * @description Who can access this tool. Default: ["model", "app"]
    * - "model": Tool visible to and callable by the agent
@@ -793,6 +804,17 @@ export interface McpUiToolMeta {
    * not the tool. Hosts ignore it here.
    */
   permissions?: never;
+}
+
+/**
+ * @description MCP Apps metadata for a tool execution result.
+ */
+export interface McpUiToolResultMeta {
+  /**
+   * @description Whether the host should close or suppress the View associated
+   * with this tool invocation. Default: false
+   */
+  "ui/close"?: boolean;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,8 +64,10 @@ export {
   type McpUiResourceMeta,
   type McpUiRequestDisplayModeRequest,
   type McpUiRequestDisplayModeResult,
+  type McpUiToolPreload,
   type McpUiToolVisibility,
   type McpUiToolMeta,
+  type McpUiToolResultMeta,
   type McpUiClientCapabilities,
 } from "./spec.types.js";
 
@@ -132,8 +134,10 @@ export {
   McpUiResourceMetaSchema,
   McpUiRequestDisplayModeRequestSchema,
   McpUiRequestDisplayModeResultSchema,
+  McpUiToolPreloadSchema,
   McpUiToolVisibilitySchema,
   McpUiToolMetaSchema,
+  McpUiToolResultMetaSchema,
 } from "./generated/schema.js";
 
 // Re-export SDK types used in protocol type unions


### PR DESCRIPTION
## Summary

- add `_meta.ui.preload` with `"optional"` (default) and `"disabled"` modes
- standardize `_meta["ui/close"]` on tool results for invocation-scoped View suppression or teardown
- expose `getToolUiPreload`, `shouldCloseToolUi`, and `UI_CLOSE_META_KEY` for host and server integrations
- generate matching Zod and JSON schemas and document the lifecycle contract in the draft specification

## Motivation

A server may only know after executing a tool whether a View adds value. Separate UI and non-UI tools do not solve cases where both variants represent the same intent and accept the same arguments, such as `search_orders(query)` returning one exact match, several possible matches, or no matches.

This keeps UI discovery early enough for host optimization while allowing servers to defer loading and suppress or close a View when the result can be presented without it.

## Compatibility

The change is additive. Existing `resourceUri` behavior remains the default, omitted or unrecognized preload modes resolve to `"optional"`, hosts may ignore metadata they do not recognize, and no new RPC method or transport behavior is introduced.

## Validation

- `npm run build`
- `npm exec bun test src` (290 passed)
- `npm exec bun test src/app-bridge.test.ts` (156 passed)
- `typedoc --treatValidationWarningsAsErrors --emit none`
- Prettier check for all changed source and generated files

`npm test` completed with 377 passed and 2 skipped; 2 unrelated PDF-server tests could not create directory symlinks on Windows (`EPERM`) before their assertions ran.

Closes #744.

Follow-up to https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/3260, which was moved here per MCP Apps Working Group guidance.