### PR TITLE
CI: build the WSL job on ext4, skip the unused Chromium download, list tsconfig types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,10 @@ jobs:
 
       - run: npm ci
 
+      # Headless runs without a channel use chromium-headless-shell, so the
+      # full Chromium build (about 165 MB) would only be downloaded, never run.
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps --only-shell chromium
 
       - name: Run E2E tests
         run: npx playwright test --reporter=list
@@ -180,9 +182,14 @@ jobs:
           curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
           sudo apt-get install -y nodejs
 
+      # The checkout lives on the Windows drive, which WSL reaches over 9P;
+      # writing node_modules there is what makes this job slow (npm ci alone
+      # took about 3 minutes). Copy the tree onto the distro's ext4 filesystem
+      # first, as Microsoft's WSL guidance recommends for anything I/O heavy.
       - name: Build and test in WSL
         shell: wsl-bash {0}
         run: |
+          cp -r "$(pwd)" ~/ext-apps && cd ~/ext-apps
           npm ci
           npm run build
           npm run examples:build

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,6 +59,7 @@ npm pkg set scripts.start='concurrently --raw "cross-env NODE_ENV=development IN
 ```json source="../examples/quickstart/tsconfig.json"
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
@@ -87,6 +88,7 @@ npm pkg set scripts.start='concurrently --raw "cross-env NODE_ENV=development IN
 ```json source="../examples/quickstart/tsconfig.server.json"
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/basic-host/tsconfig.json
+++ b/examples/basic-host/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/basic-server-preact/tsconfig.json
+++ b/examples/basic-server-preact/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/basic-server-preact/tsconfig.server.json
+++ b/examples/basic-server-preact/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/basic-server-react/tsconfig.json
+++ b/examples/basic-server-react/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/basic-server-react/tsconfig.server.json
+++ b/examples/basic-server-react/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/basic-server-solid/tsconfig.json
+++ b/examples/basic-server-solid/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/basic-server-solid/tsconfig.server.json
+++ b/examples/basic-server-solid/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/basic-server-svelte/tsconfig.json
+++ b/examples/basic-server-svelte/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/basic-server-svelte/tsconfig.server.json
+++ b/examples/basic-server-svelte/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/basic-server-vanillajs/tsconfig.json
+++ b/examples/basic-server-vanillajs/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/basic-server-vanillajs/tsconfig.server.json
+++ b/examples/basic-server-vanillajs/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/basic-server-vue/tsconfig.json
+++ b/examples/basic-server-vue/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/basic-server-vue/tsconfig.server.json
+++ b/examples/basic-server-vue/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/budget-allocator-server/tsconfig.json
+++ b/examples/budget-allocator-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/budget-allocator-server/tsconfig.server.json
+++ b/examples/budget-allocator-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/cohort-heatmap-server/tsconfig.json
+++ b/examples/cohort-heatmap-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/cohort-heatmap-server/tsconfig.server.json
+++ b/examples/cohort-heatmap-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/customer-segmentation-server/tsconfig.json
+++ b/examples/customer-segmentation-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/customer-segmentation-server/tsconfig.server.json
+++ b/examples/customer-segmentation-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/debug-server/tsconfig.json
+++ b/examples/debug-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/debug-server/tsconfig.server.json
+++ b/examples/debug-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/integration-server/tsconfig.json
+++ b/examples/integration-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/integration-server/tsconfig.server.json
+++ b/examples/integration-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/lazy-auth-server/tsconfig.json
+++ b/examples/lazy-auth-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/lazy-auth-server/tsconfig.server.json
+++ b/examples/lazy-auth-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/map-server/tsconfig.json
+++ b/examples/map-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/map-server/tsconfig.server.json
+++ b/examples/map-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/pdf-server/tsconfig.json
+++ b/examples/pdf-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client", "bun"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/pdf-server/tsconfig.server.json
+++ b/examples/pdf-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/quickstart/tsconfig.json
+++ b/examples/quickstart/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/quickstart/tsconfig.server.json
+++ b/examples/quickstart/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/scenario-modeler-server/tsconfig.json
+++ b/examples/scenario-modeler-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/scenario-modeler-server/tsconfig.server.json
+++ b/examples/scenario-modeler-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/shadertoy-server/tsconfig.json
+++ b/examples/shadertoy-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/shadertoy-server/tsconfig.server.json
+++ b/examples/shadertoy-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/sheet-music-server/tsconfig.json
+++ b/examples/sheet-music-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/sheet-music-server/tsconfig.server.json
+++ b/examples/sheet-music-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/system-monitor-server/tsconfig.json
+++ b/examples/system-monitor-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/system-monitor-server/tsconfig.server.json
+++ b/examples/system-monitor-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/threejs-server/tsconfig.json
+++ b/examples/threejs-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/threejs-server/tsconfig.server.json
+++ b/examples/threejs-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/transcript-server/tsconfig.json
+++ b/examples/transcript-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client", "dom-speech-recognition"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/transcript-server/tsconfig.server.json
+++ b/examples/transcript-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/video-resource-server/tsconfig.json
+++ b/examples/video-resource-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/video-resource-server/tsconfig.server.json
+++ b/examples/video-resource-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/examples/wiki-explorer-server/tsconfig.json
+++ b/examples/wiki-explorer-server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "vite/client"],
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/wiki-explorer-server/tsconfig.server.json
+++ b/examples/wiki-explorer-server/tsconfig.server.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "NodeNext",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node", "bun"],
     "target": "ES2020",
     "module": "ESNext",
     "lib": ["ES2020", "DOM"],


### PR DESCRIPTION
Three changes, each measured or verified before landing; two cache-based approaches were tried first and dropped (details at the end).

**WSL job on ext4.** `Build (Windows WSL)` is the critical path of every CI run (589 to 752 s across the last six). Its checkout is on the Windows drive, which WSL reaches over 9P; `npm ci` there takes about 3 minutes against 23 s on the Linux job with the same lockfile. The step now copies the tree onto the distro's ext4 filesystem first, which is what Microsoft's WSL docs recommend for anything I/O heavy. Everything the job does (install, build, examples, tests, prettier) runs on the copy; nothing downstream reads the original.

**`--only-shell` for Playwright.** The e2e job downloaded the full Chromium build (about 165 MB) on every run, but a headless run with no channel launches `chromium-headless-shell` and never opens it (`PW_CHANNEL` is unset in CI). Same command, one flag.

**Explicit `types` in every tsconfig.** 48 tsconfigs now list the `@types` packages they use (`node`, `bun`, `vite/client`, `dom-speech-recognition`) instead of relying on TypeScript auto-including everything under `node_modules/@types`. On TypeScript 5.9 this is a no-op, checked project by project: identical exit codes and diagnostics across all 48, no source file dropped from any program, and byte-identical emitted `.d.ts` for the root and the 23 example servers. It is the prerequisite for TypeScript 7 (the Go compiler), which drops auto-inclusion: on main the TS 7 compiler fails 41 of 48 projects on exactly that, and with these lists it passes all 48, 7 to 8× faster per project. The upgrade itself waits on TypeDoc, which still needs the TS 5/6 compiler API (TypeStrong/typedoc#3098, maintainer expects support around TS 7.1). Note for that future flip: TS 7 emits a slightly different `app-bridge.d.ts`, so it should be a version bump for checking first, with declaration emit staying on the old compiler until the output is reviewed.

**Rejected.** An npm cache for the WSL job (`actions/cache` on a Windows-side dir): mechanically sound, but `npm ci` is slow there because of 9P, not downloads (tarball caching is worth 7 to 13 s elsewhere), and a prefix-restored cache grows without bound under npm's no-prune cacache. A Playwright browser cache: Playwright's own CI docs say not to, and the measured download is 9.6 s on a job 100 s or more off the critical path.
