### PR TITLE
Use the canonical git+https form for repository.url

### DIFF
--- a/examples/basic-server-preact/package.json
+++ b/examples/basic-server-preact/package.json
@@ -5,7 +5,7 @@
   "description": "Basic MCP App Server example using Preact",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/basic-server-preact"
   },
   "license": "MIT",

--- a/examples/basic-server-react/package.json
+++ b/examples/basic-server-react/package.json
@@ -5,7 +5,7 @@
   "description": "Basic MCP App Server example using React",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/basic-server-react"
   },
   "license": "MIT",

--- a/examples/basic-server-solid/package.json
+++ b/examples/basic-server-solid/package.json
@@ -5,7 +5,7 @@
   "description": "Basic MCP App Server example using Solid",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/basic-server-solid"
   },
   "license": "MIT",

--- a/examples/basic-server-svelte/package.json
+++ b/examples/basic-server-svelte/package.json
@@ -5,7 +5,7 @@
   "description": "Basic MCP App Server example using Svelte",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/basic-server-svelte"
   },
   "license": "MIT",

--- a/examples/basic-server-vanillajs/package.json
+++ b/examples/basic-server-vanillajs/package.json
@@ -5,7 +5,7 @@
   "description": "Basic MCP App Server example using vanilla JavaScript",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/basic-server-vanillajs"
   },
   "license": "MIT",

--- a/examples/basic-server-vue/package.json
+++ b/examples/basic-server-vue/package.json
@@ -5,7 +5,7 @@
   "description": "Basic MCP App Server example using Vue",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/basic-server-vue"
   },
   "license": "MIT",

--- a/examples/budget-allocator-server/package.json
+++ b/examples/budget-allocator-server/package.json
@@ -5,7 +5,7 @@
   "description": "Budget allocator MCP App Server with interactive visualization",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/budget-allocator-server"
   },
   "license": "MIT",

--- a/examples/cohort-heatmap-server/package.json
+++ b/examples/cohort-heatmap-server/package.json
@@ -5,7 +5,7 @@
   "description": "Cohort heatmap MCP App Server for retention analysis",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/cohort-heatmap-server"
   },
   "license": "MIT",

--- a/examples/customer-segmentation-server/package.json
+++ b/examples/customer-segmentation-server/package.json
@@ -5,7 +5,7 @@
   "description": "Customer segmentation MCP App Server with filtering",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/customer-segmentation-server"
   },
   "license": "MIT",

--- a/examples/debug-server/package.json
+++ b/examples/debug-server/package.json
@@ -5,7 +5,7 @@
   "description": "Debug MCP App Server for testing all SDK capabilities",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/debug-server"
   },
   "license": "MIT",

--- a/examples/lazy-auth-server/package.json
+++ b/examples/lazy-auth-server/package.json
@@ -5,7 +5,7 @@
   "description": "MCP App example demonstrating lazy (on-demand) OAuth: public tools work unauthenticated, protected tools return 401 + WWW-Authenticate so the host runs the OAuth flow only when needed",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/lazy-auth-server"
   },
   "license": "MIT",

--- a/examples/map-server/package.json
+++ b/examples/map-server/package.json
@@ -5,7 +5,7 @@
   "description": "MCP App Server example with CesiumJS 3D globe and geocoding",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/map-server"
   },
   "license": "MIT",

--- a/examples/pdf-server/package.json
+++ b/examples/pdf-server/package.json
@@ -5,7 +5,7 @@
   "description": "MCP server for loading and extracting text from PDF files with chunked pagination and interactive viewer",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/pdf-server"
   },
   "license": "MIT",

--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -6,7 +6,7 @@
   "description": "Quickstart MCP App Server example",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/quickstart"
   },
   "license": "MIT",

--- a/examples/say-server/package.json
+++ b/examples/say-server/package.json
@@ -5,7 +5,7 @@
   "description": "Streaming TTS MCP App Server with karaoke-style text highlighting",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/say-server"
   },
   "license": "MIT",

--- a/examples/scenario-modeler-server/package.json
+++ b/examples/scenario-modeler-server/package.json
@@ -5,7 +5,7 @@
   "description": "Financial scenario modeling MCP App Server",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/scenario-modeler-server"
   },
   "license": "MIT",

--- a/examples/shadertoy-server/package.json
+++ b/examples/shadertoy-server/package.json
@@ -5,7 +5,7 @@
   "description": "MCP App Server example for rendering ShaderToy-compatible GLSL shaders",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/shadertoy-server"
   },
   "license": "MIT",

--- a/examples/sheet-music-server/package.json
+++ b/examples/sheet-music-server/package.json
@@ -5,7 +5,7 @@
   "description": "MCP App Server for rendering and playing sheet music from ABC notation",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/sheet-music-server"
   },
   "license": "MIT",

--- a/examples/system-monitor-server/package.json
+++ b/examples/system-monitor-server/package.json
@@ -5,7 +5,7 @@
   "description": "System monitor MCP App Server with real-time stats",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/system-monitor-server"
   },
   "license": "MIT",

--- a/examples/threejs-server/package.json
+++ b/examples/threejs-server/package.json
@@ -5,7 +5,7 @@
   "description": "Three.js 3D visualization MCP App Server",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/threejs-server"
   },
   "license": "MIT",

--- a/examples/transcript-server/package.json
+++ b/examples/transcript-server/package.json
@@ -5,7 +5,7 @@
   "description": "MCP App Server for live speech transcription",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/transcript-server"
   },
   "license": "MIT",

--- a/examples/video-resource-server/package.json
+++ b/examples/video-resource-server/package.json
@@ -5,7 +5,7 @@
   "description": "MCP App Server demonstrating video resources served as base64 blobs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/video-resource-server"
   },
   "license": "MIT",

--- a/examples/wiki-explorer-server/package.json
+++ b/examples/wiki-explorer-server/package.json
@@ -5,7 +5,7 @@
   "description": "Wikipedia link explorer MCP App Server with graph visualization",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps",
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git",
     "directory": "examples/wiki-explorer-server"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@modelcontextprotocol/ext-apps",
   "repository": {
     "type": "git",
-    "url": "https://github.com/modelcontextprotocol/ext-apps"
+    "url": "git+https://github.com/modelcontextprotocol/ext-apps.git"
   },
   "homepage": "https://github.com/modelcontextprotocol/ext-apps",
   "version": "2.0.0",


### PR DESCRIPTION
Every publish job warned `"repository.url" was normalized to "git+https://github.com/modelcontextprotocol/ext-apps.git"` (1.7.5 did too). This stores the canonical form in the 24 manifests that set it, which is what `npm pkg fix` produces. No change to published tarballs beyond the manifest field; the examples' `directory` fields are untouched. It also matches the form npm's trusted-publisher check compares against the repository, ahead of that switch.