### PR TITLE
fix(server): don't crash registerAppTool when config._meta is omitted

### DIFF
--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -16,6 +16,34 @@ import { Client } from "@modelcontextprotocol/client";
 import { z } from "zod/v4";
 
 describe("registerAppTool", () => {
+  it("registers a tool without _meta (optional per ToolConfig)", () => {
+    let capturedConfig: Record<string, unknown> | undefined;
+    const mockServer = {
+      registerTool: mock(
+        (name: string, config: Record<string, unknown>, handler: unknown) => {
+          capturedConfig = config;
+        },
+      ),
+      registerResource: mock(() => {}),
+    };
+
+    const handler = async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+    });
+
+    // No _meta at all — previously crashed reading `.ui` of undefined.
+    expect(() =>
+      registerAppTool(
+        mockServer as unknown as Pick<McpServer, "registerTool">,
+        "plain-tool",
+        { title: "Plain Tool", description: "No UI metadata" },
+        handler,
+      ),
+    ).not.toThrow();
+    expect(mockServer.registerTool).toHaveBeenCalledTimes(1);
+    expect(capturedConfig?._meta).toEqual({});
+  });
+
   it("should pass through config to server.registerTool", () => {
     let capturedName: string | undefined;
     let capturedConfig: Record<string, unknown> | undefined;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -284,7 +284,8 @@ export function registerAppTool(
   // Normalize metadata for backward compatibility:
   // - If _meta.ui.resourceUri is set, also set the legacy flat key
   // - If the legacy flat key is set, also set _meta.ui.resourceUri
-  const meta = config._meta;
+  // `ToolConfig._meta` is optional; default it before reading `meta.ui`.
+  const meta = config._meta ?? {};
   const uiMeta = meta.ui as McpUiToolMeta | undefined;
   const legacyUri = meta[RESOURCE_URI_META_KEY] as string | undefined;
 


### PR DESCRIPTION
## What

Guard the UI-metadata normalization in `registerAppTool` with `config._meta ?? {}`.

## Why

`ToolConfig._meta` is typed optional (`_meta?`), but `registerAppTool` read `config._meta.ui` unconditionally. Registering a tool **without** UI metadata — a valid use, since not every tool on an MCP Apps server renders a view — crashed on the first request:

```
TypeError: Cannot read properties of undefined (reading 'ui')
```

Repro:

```ts
registerAppTool(server, "plain-tool", {
  title: "Plain Tool",
  description: "No UI metadata",
}, async () => ({ content: [{ type: "text", text: "ok" }] }));
// → TypeError when the server handles the first request
```

## Changes

- `src/server/index.ts`: default `config._meta` to `{}` before normalization
- `src/server/index.test.ts`: regression test — registering without `_meta` succeeds and passes `_meta: {}` through

`bun test src/server/index.test.ts` → 16 pass, 0 fail.
